### PR TITLE
Feature/Separate logrus instance for SDK

### DIFF
--- a/auth/service.go
+++ b/auth/service.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	log "github.com/sirupsen/logrus"
-
 	sdk "github.com/OrbisSystems/orbis-sdk-go/interfaces"
 	"github.com/OrbisSystems/orbis-sdk-go/model"
 )
@@ -21,7 +19,6 @@ func New(storage sdk.Storage) *Auth {
 
 // SetToken store token to the storage.
 func (a *Auth) SetToken(ctx context.Context, token model.Token) error {
-	log.Trace("setting token to storage")
 	bb, err := json.Marshal(token)
 	if err != nil {
 		return err
@@ -31,7 +28,6 @@ func (a *Auth) SetToken(ctx context.Context, token model.Token) error {
 
 // GetToken returns token from the storage.
 func (a *Auth) GetToken(ctx context.Context) (model.Token, error) {
-	log.Tracef("getting token from storage")
 	data, err := a.storage.Get(ctx)
 	if err != nil {
 		return model.Token{}, err

--- a/client/account/account.go
+++ b/client/account/account.go
@@ -27,8 +27,6 @@ type Account struct {
 
 	cli sdk.HTTPClient
 
-	watchTokenRefreshState bool
-
 	refreshTicker      *time.Ticker
 	monitorTokenTicker *time.Ticker
 }

--- a/client/account/account_test.go
+++ b/client/account/account_test.go
@@ -184,8 +184,7 @@ func TestAccount_LoginByEmail(t *testing.T) {
 					Auth: auth,
 					cli:  cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -214,8 +213,7 @@ func TestAccount_LoginByEmail(t *testing.T) {
 					Auth: auth,
 					cli:  cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -241,8 +239,7 @@ func TestAccount_LoginByEmail(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -261,8 +258,7 @@ func TestAccount_LoginByEmail(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -342,8 +338,7 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 					Auth: auth,
 					cli:  cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -372,8 +367,7 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 					Auth: auth,
 					cli:  cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -399,8 +393,7 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -419,8 +412,7 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -488,8 +480,7 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -515,8 +506,7 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -535,8 +525,7 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -614,8 +603,7 @@ func TestAccount_RefreshToken(t *testing.T) {
 					Auth: auth,
 					cli:  cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -645,8 +633,7 @@ func TestAccount_RefreshToken(t *testing.T) {
 					Auth: auth,
 					cli:  cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -675,8 +662,7 @@ func TestAccount_RefreshToken(t *testing.T) {
 					Auth: auth,
 					cli:  cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -698,8 +684,7 @@ func TestAccount_RefreshToken(t *testing.T) {
 					Auth: auth,
 					cli:  cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -715,8 +700,7 @@ func TestAccount_RefreshToken(t *testing.T) {
 				return &Account{
 					Auth: auth,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -732,8 +716,7 @@ func TestAccount_RefreshToken(t *testing.T) {
 				return &Account{
 					Auth: auth,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -794,8 +777,7 @@ func TestAccount_GetUserByID(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -819,8 +801,7 @@ func TestAccount_GetUserByID(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -837,8 +818,7 @@ func TestAccount_GetUserByID(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},

--- a/client/account/account_test.go
+++ b/client/account/account_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -25,7 +26,7 @@ func TestNew(t *testing.T) {
 
 	auth.EXPECT().GetToken(gomock.Any()).Return(model.Token{}, nil).AnyTimes()
 
-	assert.NotNil(t, New(auth, cli))
+	assert.NotNil(t, New(auth, cli, logrus.New()))
 }
 
 func TestAccount_NeedToLogin(t *testing.T) {
@@ -50,7 +51,7 @@ func TestAccount_NeedToLogin(t *testing.T) {
 					PairId:           "123123123",
 				}, nil).MaxTimes(2)
 
-				return New(auth, nil)
+				return New(auth, nil, logrus.New())
 			},
 		},
 		{
@@ -69,7 +70,7 @@ func TestAccount_NeedToLogin(t *testing.T) {
 					PairId:           "123123123",
 				}, nil).MaxTimes(2)
 
-				return New(auth, nil)
+				return New(auth, nil, logrus.New())
 			},
 		},
 		{
@@ -88,7 +89,7 @@ func TestAccount_NeedToLogin(t *testing.T) {
 					PairId:           "123123123",
 				}, nil).MaxTimes(2)
 
-				return New(auth, nil)
+				return New(auth, nil, logrus.New())
 			},
 		},
 		{
@@ -101,7 +102,7 @@ func TestAccount_NeedToLogin(t *testing.T) {
 
 				auth.EXPECT().GetToken(ctx).Return(model.Token{}, errors.New("error")).MaxTimes(2)
 
-				return New(auth, nil)
+				return New(auth, nil, logrus.New())
 			},
 		},
 	}
@@ -181,8 +182,9 @@ func TestAccount_LoginByEmail(t *testing.T) {
 				auth.EXPECT().SetToken(ctx, token.LoginBasic.Tokens).Return(nil)
 
 				return &Account{
-					Auth: auth,
-					cli:  cli,
+					Auth:   auth,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -210,8 +212,9 @@ func TestAccount_LoginByEmail(t *testing.T) {
 				auth.EXPECT().SetToken(ctx, token.LoginBasic.Tokens).Return(testErr)
 
 				return &Account{
-					Auth: auth,
-					cli:  cli,
+					Auth:   auth,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -237,7 +240,8 @@ func TestAccount_LoginByEmail(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BLoginByEmail, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -256,7 +260,8 @@ func TestAccount_LoginByEmail(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BLoginByEmail, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -335,8 +340,9 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 				auth.EXPECT().SetToken(ctx, token.ApiKeysLogin.Tokens).Return(nil)
 
 				return &Account{
-					Auth: auth,
-					cli:  cli,
+					Auth:   auth,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -364,8 +370,9 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 				auth.EXPECT().SetToken(ctx, token.ApiKeysLogin.Tokens).Return(testErr)
 
 				return &Account{
-					Auth: auth,
-					cli:  cli,
+					Auth:   auth,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -391,7 +398,8 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BLoginByAPIKey, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -410,7 +418,8 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BLoginByAPIKey, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -478,7 +487,8 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BCreateAPIKey, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -504,7 +514,8 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BCreateAPIKey, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -523,7 +534,8 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BCreateAPIKey, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -600,8 +612,9 @@ func TestAccount_RefreshToken(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BRefreshToken, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					Auth: auth,
-					cli:  cli,
+					Auth:   auth,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -630,8 +643,9 @@ func TestAccount_RefreshToken(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BRefreshToken, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					Auth: auth,
-					cli:  cli,
+					Auth:   auth,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -659,8 +673,9 @@ func TestAccount_RefreshToken(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BRefreshToken, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					Auth: auth,
-					cli:  cli,
+					Auth:   auth,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -681,8 +696,9 @@ func TestAccount_RefreshToken(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BRefreshToken, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Account{
-					Auth: auth,
-					cli:  cli,
+					Auth:   auth,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -698,7 +714,8 @@ func TestAccount_RefreshToken(t *testing.T) {
 				auth.EXPECT().GetToken(ctx).Return(model.Token{}, testErr)
 
 				return &Account{
-					Auth: auth,
+					Auth:   auth,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -714,7 +731,8 @@ func TestAccount_RefreshToken(t *testing.T) {
 				auth.EXPECT().GetToken(ctx).Return(model.Token{}, nil)
 
 				return &Account{
-					Auth: auth,
+					Auth:   auth,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -775,7 +793,8 @@ func TestAccount_GetUserByID(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%d", model.URLB2BGetUserByID, id), nil).Return(httpResponse, nil)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -799,7 +818,8 @@ func TestAccount_GetUserByID(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%d", model.URLB2BGetUserByID, id), nil).Return(httpResponse, nil)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -816,7 +836,8 @@ func TestAccount_GetUserByID(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%d", model.URLB2BGetUserByID, id), nil).Return(nil, testErr)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}

--- a/client/account/account_v2.go
+++ b/client/account/account_v2.go
@@ -8,11 +8,10 @@ import (
 	"github.com/OrbisSystems/orbis-sdk-go/model"
 	"github.com/OrbisSystems/orbis-sdk-go/utils"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 func (a *Account) GetB2BUsersV2(ctx context.Context, req model.GetB2BUsersV2Request) (model.GetB2BUsersV2Response, error) {
-	log.Trace("GetB2BUsersV2 called")
+	a.logger.Trace("GetB2BUsersV2 called")
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/client/account/account_v2_test.go
+++ b/client/account/account_v2_test.go
@@ -70,8 +70,7 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -96,8 +95,7 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -122,8 +120,7 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				return &Account{
 					cli: cli,
 
-					watchTokenRefreshState: true,
-					refreshTicker:          time.NewTicker(time.Hour * 100),
+					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},

--- a/client/account/account_v2_test.go
+++ b/client/account/account_v2_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -68,7 +69,8 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BGetUsersV2, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -93,7 +95,8 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BGetUsersV2, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
@@ -118,7 +121,8 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLB2BGetUsersV2, bytes.NewBuffer(bb), nil).Return(httpResponse, testErr)
 
 				return &Account{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 
 					refreshTicker: time.NewTicker(time.Hour * 100),
 				}

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/OrbisSystems/orbis-sdk-go/client/account"
@@ -62,25 +63,26 @@ func NewSDK(cfg config.Config, auth sdk.Auth) *Client {
 }
 
 func newCli(cfg config.Config, auth sdk.Auth, httpClient sdk.HTTPClient) *Client {
-	log.SetLevel(getLogLevel(cfg.LogLevel))
-	log.SetFormatter(&log.JSONFormatter{})
-	log.SetOutput(os.Stderr)
+	logger := logrus.New()
+	logger.SetFormatter(&log.JSONFormatter{})
+	logger.SetOutput(os.Stderr)
+	logger.SetLevel(getLogLevel(cfg.LogLevel))
 
 	return &Client{
-		Account:      account.New(auth, httpClient),
-		News:         news.New(httpClient),
-		Logos:        logos.New(httpClient),
-		Passport:     passport.New(httpClient),
-		TipRank:      tiprank.New(httpClient),
-		Quote:        quotes.New(httpClient),
-		Funds:        funds.New(httpClient),
-		Research:     research.New(httpClient),
-		IPO:          ipo.New(httpClient),
-		WorldMarket:  market.New(httpClient),
-		MarketDates:  dates.New(httpClient),
-		OptionGreeks: og.New(httpClient),
-		HoopsAI:      hs.New(httpClient),
-		FixedIncome:  fi.New(httpClient),
+		Account:      account.New(auth, httpClient, logger),
+		News:         news.New(httpClient, logger),
+		Logos:        logos.New(httpClient, logger),
+		Passport:     passport.New(httpClient, logger),
+		TipRank:      tiprank.New(httpClient, logger),
+		Quote:        quotes.New(httpClient, logger),
+		Funds:        funds.New(httpClient, logger),
+		Research:     research.New(httpClient, logger),
+		IPO:          ipo.New(httpClient, logger),
+		WorldMarket:  market.New(httpClient, logger),
+		MarketDates:  dates.New(httpClient, logger),
+		OptionGreeks: og.New(httpClient, logger),
+		HoopsAI:      hs.New(httpClient, logger),
+		FixedIncome:  fi.New(httpClient, logger),
 		WS:           ws.New(cfg, auth),
 	}
 }

--- a/client/dates/market_dates.go
+++ b/client/dates/market_dates.go
@@ -15,17 +15,19 @@ import (
 )
 
 type MarketDates struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *MarketDates {
+func New(cli sdk.HTTPClient, logger *log.Logger) *MarketDates {
 	return &MarketDates{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (m *MarketDates) GetMarketDatesHistory(ctx context.Context, req model.GetMarketDatesRequest) (model.GetMarketDatesResponse, error) {
-	log.Trace("GetMarketDatesHistory called")
+	m.logger.Trace("GetMarketDatesHistory called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -47,7 +49,7 @@ func (m *MarketDates) GetMarketDatesHistory(ctx context.Context, req model.GetMa
 }
 
 func (m *MarketDates) GetTodayMarketHours(ctx context.Context, market string) (model.GetMarketHoursResponse, error) {
-	log.Trace("GetTodayMarketHours called")
+	m.logger.Trace("GetTodayMarketHours called")
 
 	r, err := m.cli.Get(ctx, fmt.Sprintf("%s?market=%s", model.URLInsightBase+model.URLInsightMarketDatesToday, market), nil)
 	if err != nil {

--- a/client/dates/market_dates_test.go
+++ b/client/dates/market_dates_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestMarketDates_GetMarketDatesHistory(t *testing.T) {
@@ -69,7 +70,8 @@ func TestMarketDates_GetMarketDatesHistory(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightMarketDatesHistory, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &MarketDates{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -97,7 +99,8 @@ func TestMarketDates_GetMarketDatesHistory(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightMarketDatesHistory, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &MarketDates{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -118,7 +121,8 @@ func TestMarketDates_GetMarketDatesHistory(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightMarketDatesHistory, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &MarketDates{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -178,7 +182,8 @@ func TestMarketDates_GetTodayMarketHours(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?market=%s", model.URLInsightBase+model.URLInsightMarketDatesToday, market), nil).Return(httpResponse, nil)
 
 				return &MarketDates{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -200,7 +205,8 @@ func TestMarketDates_GetTodayMarketHours(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?market=%s", model.URLInsightBase+model.URLInsightMarketDatesToday, market), nil).Return(httpResponse, nil)
 
 				return &MarketDates{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -215,7 +221,8 @@ func TestMarketDates_GetTodayMarketHours(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?market=%s", model.URLInsightBase+model.URLInsightMarketDatesToday, market), nil).Return(nil, testErr)
 
 				return &MarketDates{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/fi/fixed_income.go
+++ b/client/fi/fixed_income.go
@@ -16,17 +16,19 @@ import (
 
 // FixedIncome service provides information about fixed income
 type FixedIncome struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *FixedIncome {
+func New(cli sdk.HTTPClient, logger *log.Logger) *FixedIncome {
 	return &FixedIncome{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (f *FixedIncome) GetFixedIncomeEntryByID(ctx context.Context, id string) (model.FixedIncome, error) {
-	log.Trace("GetFixedIncomeEntryByID called")
+	f.logger.Trace("GetFixedIncomeEntryByID called")
 
 	r, err := f.cli.Get(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightFixedIncome, id), nil)
 	if err != nil {
@@ -43,7 +45,7 @@ func (f *FixedIncome) GetFixedIncomeEntryByID(ctx context.Context, id string) (m
 }
 
 func (f *FixedIncome) GetFixedIncomeEntries(ctx context.Context, req model.GetFixedIncomeEntriesRequest) (model.GetFixedIncomeEntriesResponse, error) {
-	log.Trace("GetFixedIncomeEntries called")
+	f.logger.Trace("GetFixedIncomeEntries called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -65,7 +67,7 @@ func (f *FixedIncome) GetFixedIncomeEntries(ctx context.Context, req model.GetFi
 }
 
 func (f *FixedIncome) GetFixedIncomeHistorical(ctx context.Context, req model.GetFixedIncomeHistoricalRequest) (model.GetFixedIncomeHistoricalResponse, error) {
-	log.Trace("GetFixedIncomeHistorical called")
+	f.logger.Trace("GetFixedIncomeHistorical called")
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/client/fi/fixed_income_test.go
+++ b/client/fi/fixed_income_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -22,7 +23,7 @@ func toPointer[T any](val T) *T {
 }
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestFunds_GetFixedIncomeEntryByID(t *testing.T) {
@@ -78,7 +79,8 @@ func TestFunds_GetFixedIncomeEntryByID(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightFixedIncome, id), nil).Return(httpResponse, nil)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -100,7 +102,8 @@ func TestFunds_GetFixedIncomeEntryByID(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightFixedIncome, id), nil).Return(httpResponse, nil)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -115,7 +118,8 @@ func TestFunds_GetFixedIncomeEntryByID(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightFixedIncome, id), nil).Return(nil, testErr)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -200,7 +204,8 @@ func TestFunds_GetFixedIncomeEntries(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFixedIncome, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -226,7 +231,8 @@ func TestFunds_GetFixedIncomeEntries(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFixedIncome, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -245,7 +251,8 @@ func TestFunds_GetFixedIncomeEntries(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFixedIncome, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -316,7 +323,8 @@ func TestFunds_GetFixedIncomeHistorical(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFixedIncomeHistorical, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -342,7 +350,8 @@ func TestFunds_GetFixedIncomeHistorical(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFixedIncomeHistorical, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -361,7 +370,8 @@ func TestFunds_GetFixedIncomeHistorical(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFixedIncomeHistorical, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &FixedIncome{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/funds/funds.go
+++ b/client/funds/funds.go
@@ -16,17 +16,19 @@ import (
 
 // Funds service returns different funds info such as screener, top, etc.
 type Funds struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *Funds {
+func New(cli sdk.HTTPClient, logger *log.Logger) *Funds {
 	return &Funds{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (f *Funds) GetFundDetails(ctx context.Context, symbol string) (model.GetFundDetailsResponse, error) {
-	log.Trace("GetFundDetails called")
+	f.logger.Trace("GetFundDetails called")
 
 	r, err := f.cli.Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightFundsDetails, symbol), nil)
 	if err != nil {
@@ -43,7 +45,7 @@ func (f *Funds) GetFundDetails(ctx context.Context, symbol string) (model.GetFun
 }
 
 func (f *Funds) GetFundScreenerFilters(ctx context.Context) (model.GetFundScreenerFiltersResponse, error) {
-	log.Trace("GetFundScreenerFilters called")
+	f.logger.Trace("GetFundScreenerFilters called")
 
 	r, err := f.cli.Get(ctx, model.URLInsightBase+model.URLInsightFundsScreenerFilters, nil)
 	if err != nil {
@@ -60,7 +62,7 @@ func (f *Funds) GetFundScreenerFilters(ctx context.Context) (model.GetFundScreen
 }
 
 func (f *Funds) ScreenFunds(ctx context.Context, req model.FundScreenerRequest) (model.FundScreenerResponse, error) {
-	log.Trace("ScreenFunds called")
+	f.logger.Trace("ScreenFunds called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -82,7 +84,7 @@ func (f *Funds) ScreenFunds(ctx context.Context, req model.FundScreenerRequest) 
 }
 
 func (f *Funds) ScreenSectorFunds(ctx context.Context, req model.FundSectorScreenerRequest) (model.FundScreenerResponse, error) {
-	log.Trace("ScreenSectorFunds called")
+	f.logger.Trace("ScreenSectorFunds called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -104,7 +106,7 @@ func (f *Funds) ScreenSectorFunds(ctx context.Context, req model.FundSectorScree
 }
 
 func (f *Funds) GetTopFunds(ctx context.Context, req model.GetTopFundsRequest) ([]string, error) {
-	log.Trace("GetTopFunds called")
+	f.logger.Trace("GetTopFunds called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -126,7 +128,7 @@ func (f *Funds) GetTopFunds(ctx context.Context, req model.GetTopFundsRequest) (
 }
 
 func (f *Funds) GetFundsForHolding(ctx context.Context, req model.GetFundsForHoldingRequest) (model.GetFundsForHoldingResponse, error) {
-	log.Trace("GetFundsForHolding called")
+	f.logger.Trace("GetFundsForHolding called")
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/client/funds/funds_test.go
+++ b/client/funds/funds_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestFunds_GetFundDetails(t *testing.T) {
@@ -59,7 +60,8 @@ func TestFunds_GetFundDetails(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightFundsDetails, symbol), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -81,7 +83,8 @@ func TestFunds_GetFundDetails(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightFundsDetails, symbol), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -96,7 +99,8 @@ func TestFunds_GetFundDetails(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightFundsDetails, symbol), nil).Return(nil, testErr)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -158,7 +162,8 @@ func TestFunds_GetFundScreenerFilters(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightFundsScreenerFilters, nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -179,7 +184,8 @@ func TestFunds_GetFundScreenerFilters(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightFundsScreenerFilters, nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -193,7 +199,8 @@ func TestFunds_GetFundScreenerFilters(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightFundsScreenerFilters, nil).Return(nil, testErr)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -263,7 +270,8 @@ func TestFunds_ScreenFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsScreener, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -289,7 +297,8 @@ func TestFunds_ScreenFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsScreener, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -308,7 +317,8 @@ func TestFunds_ScreenFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsScreener, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -378,7 +388,8 @@ func TestFunds_ScreenSectorFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsSectorScreener, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -404,7 +415,8 @@ func TestFunds_ScreenSectorFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsSectorScreener, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -423,7 +435,8 @@ func TestFunds_ScreenSectorFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsSectorScreener, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -483,7 +496,8 @@ func TestFunds_GetTopFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsTop, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -509,7 +523,8 @@ func TestFunds_GetTopFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsTop, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -528,7 +543,8 @@ func TestFunds_GetTopFunds(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsTop, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -605,7 +621,8 @@ func TestFunds_GetFundsForHolding(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsForHolding, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -631,7 +648,8 @@ func TestFunds_GetFundsForHolding(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsForHolding, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -650,7 +668,8 @@ func TestFunds_GetFundsForHolding(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundsForHolding, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Funds{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/hs/hoopsai.go
+++ b/client/hs/hoopsai.go
@@ -15,17 +15,19 @@ import (
 )
 
 type HoopsAI struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *HoopsAI {
+func New(cli sdk.HTTPClient, logger *log.Logger) *HoopsAI {
 	return &HoopsAI{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (i *HoopsAI) DailySummary(ctx context.Context, req model.HSDailySummaryRequest) (map[string]interface{}, error) {
-	log.Trace("HS DailySummary called")
+	i.logger.Trace("HS DailySummary called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -47,7 +49,7 @@ func (i *HoopsAI) DailySummary(ctx context.Context, req model.HSDailySummaryRequ
 }
 
 func (i *HoopsAI) WeeklySummary(ctx context.Context, req model.HSWeeklySummaryRequest) (map[string]interface{}, error) {
-	log.Trace("HS WeeklySummary called")
+	i.logger.Trace("HS WeeklySummary called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -69,7 +71,7 @@ func (i *HoopsAI) WeeklySummary(ctx context.Context, req model.HSWeeklySummaryRe
 }
 
 func (i *HoopsAI) Portfolio(ctx context.Context, req model.HSPortfolioRequest) (map[string]interface{}, error) {
-	log.Trace("HS Portfolio called")
+	i.logger.Trace("HS Portfolio called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -91,7 +93,7 @@ func (i *HoopsAI) Portfolio(ctx context.Context, req model.HSPortfolioRequest) (
 }
 
 func (i *HoopsAI) Watchlist(ctx context.Context, req model.HSWatchlistRequest) (map[string]interface{}, error) {
-	log.Trace("HS Watchlist called")
+	i.logger.Trace("HS Watchlist called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -113,7 +115,7 @@ func (i *HoopsAI) Watchlist(ctx context.Context, req model.HSWatchlistRequest) (
 }
 
 func (i *HoopsAI) WatchlistByUserAndName(ctx context.Context, req model.HSWatchlistByUserAndNameRequest) (map[string]interface{}, error) {
-	log.Trace("HS WatchlistByUserAndName called")
+	i.logger.Trace("HS WatchlistByUserAndName called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -135,7 +137,7 @@ func (i *HoopsAI) WatchlistByUserAndName(ctx context.Context, req model.HSWatchl
 }
 
 func (i *HoopsAI) TopGainers(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS TopGainers called")
+	i.logger.Trace("HS TopGainers called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -157,7 +159,7 @@ func (i *HoopsAI) TopGainers(ctx context.Context, req model.HSMarketResearchRequ
 }
 
 func (i *HoopsAI) TopLosers(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS TopLosers called")
+	i.logger.Trace("HS TopLosers called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -179,7 +181,7 @@ func (i *HoopsAI) TopLosers(ctx context.Context, req model.HSMarketResearchReque
 }
 
 func (i *HoopsAI) TopMovers(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS TopMovers called")
+	i.logger.Trace("HS TopMovers called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -201,7 +203,7 @@ func (i *HoopsAI) TopMovers(ctx context.Context, req model.HSMarketResearchReque
 }
 
 func (i *HoopsAI) DownTrend(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS DownTrend called")
+	i.logger.Trace("HS DownTrend called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -223,7 +225,7 @@ func (i *HoopsAI) DownTrend(ctx context.Context, req model.HSMarketResearchReque
 }
 
 func (i *HoopsAI) UpTrend(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS UpTrend called")
+	i.logger.Trace("HS UpTrend called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -245,7 +247,7 @@ func (i *HoopsAI) UpTrend(ctx context.Context, req model.HSMarketResearchRequest
 }
 
 func (i *HoopsAI) MarketOverview(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS MarketOverview called")
+	i.logger.Trace("HS MarketOverview called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -267,7 +269,7 @@ func (i *HoopsAI) MarketOverview(ctx context.Context, req model.HSMarketResearch
 }
 
 func (i *HoopsAI) PriceTarget(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS PriceTarget called")
+	i.logger.Trace("HS PriceTarget called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -289,7 +291,7 @@ func (i *HoopsAI) PriceTarget(ctx context.Context, req model.HSMarketResearchReq
 }
 
 func (i *HoopsAI) UpcomingEarnings(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS UpcomingEarnings called")
+	i.logger.Trace("HS UpcomingEarnings called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -311,7 +313,7 @@ func (i *HoopsAI) UpcomingEarnings(ctx context.Context, req model.HSMarketResear
 }
 
 func (i *HoopsAI) RecentEarnings(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS RecentEarnings called")
+	i.logger.Trace("HS RecentEarnings called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -333,7 +335,7 @@ func (i *HoopsAI) RecentEarnings(ctx context.Context, req model.HSMarketResearch
 }
 
 func (i *HoopsAI) RecordHigh(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS RecordHigh called")
+	i.logger.Trace("HS RecordHigh called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -355,7 +357,7 @@ func (i *HoopsAI) RecordHigh(ctx context.Context, req model.HSMarketResearchRequ
 }
 
 func (i *HoopsAI) UnusualHighVolume(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS UnusualHighVolume called")
+	i.logger.Trace("HS UnusualHighVolume called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -377,7 +379,7 @@ func (i *HoopsAI) UnusualHighVolume(ctx context.Context, req model.HSMarketResea
 }
 
 func (i *HoopsAI) Data(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS Data called")
+	i.logger.Trace("HS Data called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -399,7 +401,7 @@ func (i *HoopsAI) Data(ctx context.Context, req model.HSMarketResearchRequest) (
 }
 
 func (i *HoopsAI) CustomerAssets(ctx context.Context, req model.HSMarketResearchRequest) (map[string]interface{}, error) {
-	log.Trace("HS CustomerAssets called")
+	i.logger.Trace("HS CustomerAssets called")
 
 	urlQuery, err := utils.BuildURLQueryParams(req)
 	if err != nil {
@@ -421,7 +423,7 @@ func (i *HoopsAI) CustomerAssets(ctx context.Context, req model.HSMarketResearch
 }
 
 func (i *HoopsAI) GetUsers(ctx context.Context, customer string) (map[string]interface{}, error) {
-	log.Trace("HS GetUsers called")
+	i.logger.Trace("HS GetUsers called")
 
 	r, err := i.cli.Get(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer), nil)
 	if err != nil {
@@ -438,7 +440,7 @@ func (i *HoopsAI) GetUsers(ctx context.Context, customer string) (map[string]int
 }
 
 func (i *HoopsAI) CreateUser(ctx context.Context, customer string) (map[string]interface{}, error) {
-	log.Trace("HS CreateUser called")
+	i.logger.Trace("HS CreateUser called")
 
 	r, err := i.cli.Post(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer), nil, nil)
 	if err != nil {
@@ -455,7 +457,7 @@ func (i *HoopsAI) CreateUser(ctx context.Context, customer string) (map[string]i
 }
 
 func (i *HoopsAI) DeleteUser(ctx context.Context, customer, userID string) (map[string]interface{}, error) {
-	log.Trace("HS DeleteUser called")
+	i.logger.Trace("HS DeleteUser called")
 
 	r, err := i.cli.Delete(ctx, fmt.Sprintf("%s/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID), nil, nil)
 	if err != nil {
@@ -472,7 +474,7 @@ func (i *HoopsAI) DeleteUser(ctx context.Context, customer, userID string) (map[
 }
 
 func (i *HoopsAI) CreateWatchlistByUser(ctx context.Context, customer, userID string) (map[string]interface{}, error) {
-	log.Trace("HS CreateWatchlistByUser called")
+	i.logger.Trace("HS CreateWatchlistByUser called")
 
 	r, err := i.cli.Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists", model.URLInsightBase+model.URLInsightHSUsers, customer, userID), nil, nil)
 	if err != nil {
@@ -489,7 +491,7 @@ func (i *HoopsAI) CreateWatchlistByUser(ctx context.Context, customer, userID st
 }
 
 func (i *HoopsAI) GetWatchlistByUser(ctx context.Context, customer, userID, watchlistName string) (map[string]interface{}, error) {
-	log.Trace("HS GetWatchlistByUser called")
+	i.logger.Trace("HS GetWatchlistByUser called")
 
 	r, err := i.cli.Get(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), nil)
 	if err != nil {
@@ -506,7 +508,7 @@ func (i *HoopsAI) GetWatchlistByUser(ctx context.Context, customer, userID, watc
 }
 
 func (i *HoopsAI) AddSymbolToWatchlist(ctx context.Context, customer, userID, watchlistName, symbol string) (map[string]interface{}, error) {
-	log.Trace("HS AddSymbolToWatchlist called")
+	i.logger.Trace("HS AddSymbolToWatchlist called")
 
 	r, err := i.cli.Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName, symbol), nil, nil)
 	if err != nil {
@@ -523,7 +525,7 @@ func (i *HoopsAI) AddSymbolToWatchlist(ctx context.Context, customer, userID, wa
 }
 
 func (i *HoopsAI) DeleteSymbolFromWatchlist(ctx context.Context, customer, userID, watchlistName, symbol string) (map[string]interface{}, error) {
-	log.Trace("HS DeleteSymbolFromWatchlist called")
+	i.logger.Trace("HS DeleteSymbolFromWatchlist called")
 
 	r, err := i.cli.Delete(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName, symbol), nil, nil)
 	if err != nil {
@@ -540,7 +542,7 @@ func (i *HoopsAI) DeleteSymbolFromWatchlist(ctx context.Context, customer, userI
 }
 
 func (i *HoopsAI) AddSymbolsToWatchlist(ctx context.Context, customer, userID, watchlistName string, symbols []string) (map[string]interface{}, error) {
-	log.Trace("HS AddSymbolToWatchlist called")
+	i.logger.Trace("HS AddSymbolToWatchlist called")
 
 	body, err := json.Marshal(struct {
 		SymbolList string `json:"symbol_list"`
@@ -566,7 +568,7 @@ func (i *HoopsAI) AddSymbolsToWatchlist(ctx context.Context, customer, userID, w
 }
 
 func (i *HoopsAI) DeleteWatchlistByName(ctx context.Context, customer, userID, watchlistName string) (map[string]interface{}, error) {
-	log.Trace("HS DeleteWatchlistByName called")
+	i.logger.Trace("HS DeleteWatchlistByName called")
 
 	r, err := i.cli.Delete(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), nil, nil)
 	if err != nil {
@@ -583,7 +585,7 @@ func (i *HoopsAI) DeleteWatchlistByName(ctx context.Context, customer, userID, w
 }
 
 func (i *HoopsAI) RenameWatchlist(ctx context.Context, customer, userID, oldWatchlistName, newWatchlistName string) (map[string]interface{}, error) {
-	log.Trace("HS RenameWatchlist called")
+	i.logger.Trace("HS RenameWatchlist called")
 
 	r, err := i.cli.Put(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/rename/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, oldWatchlistName, newWatchlistName), nil, nil)
 	if err != nil {

--- a/client/hs/hoopsai_test.go
+++ b/client/hs/hoopsai_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -30,7 +31,7 @@ var (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestHoopsAI_DailySummary(t *testing.T) {
@@ -57,7 +58,8 @@ func TestHoopsAI_DailySummary(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSDailySummary, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -66,7 +68,9 @@ func TestHoopsAI_DailySummary(t *testing.T) {
 			req:    model.HSDailySummaryRequest{Asset: "FB", UseCustomerAssets: true},
 			hasErr: true,
 			fn: func(ctx context.Context, req model.HSDailySummaryRequest) *HoopsAI {
-				return &HoopsAI{}
+				return &HoopsAI{
+					logger: logrus.New(),
+				}
 			},
 		},
 		{
@@ -86,7 +90,8 @@ func TestHoopsAI_DailySummary(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSDailySummary, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -101,7 +106,8 @@ func TestHoopsAI_DailySummary(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSDailySummary, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -149,7 +155,8 @@ func TestHoopsAI_WeeklySummary(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSWeeklySummary, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -158,7 +165,9 @@ func TestHoopsAI_WeeklySummary(t *testing.T) {
 			req:    model.HSWeeklySummaryRequest{Asset: "FB", UseCustomerAssets: true},
 			hasErr: true,
 			fn: func(ctx context.Context, req model.HSWeeklySummaryRequest) *HoopsAI {
-				return &HoopsAI{}
+				return &HoopsAI{
+					logger: logrus.New(),
+				}
 			},
 		},
 		{
@@ -178,7 +187,8 @@ func TestHoopsAI_WeeklySummary(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSWeeklySummary, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -193,7 +203,8 @@ func TestHoopsAI_WeeklySummary(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSWeeklySummary, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -243,7 +254,8 @@ func TestHoopsAI_Portfolio(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightHSPortfolio, bytes.NewBuffer(body), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -266,7 +278,8 @@ func TestHoopsAI_Portfolio(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightHSPortfolio, bytes.NewBuffer(body), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -283,7 +296,8 @@ func TestHoopsAI_Portfolio(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightHSPortfolio, bytes.NewBuffer(body), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -331,7 +345,8 @@ func TestHoopsAI_Watchlist(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSWatchlist, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -340,7 +355,9 @@ func TestHoopsAI_Watchlist(t *testing.T) {
 			req:    model.HSWatchlistRequest{Asset: "FB", UseCustomerAssets: true},
 			hasErr: true,
 			fn: func(ctx context.Context, req model.HSWatchlistRequest) *HoopsAI {
-				return &HoopsAI{}
+				return &HoopsAI{
+					logger: logrus.New(),
+				}
 			},
 		},
 		{
@@ -360,7 +377,8 @@ func TestHoopsAI_Watchlist(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSWatchlist, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -375,7 +393,8 @@ func TestHoopsAI_Watchlist(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s?doc_group=%s&enable_html=true&use_customer_assets=%v", model.URLInsightBase+model.URLInsightHSWatchlist, req.Asset, req.DocGroup, req.UseCustomerAssets), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -423,7 +442,8 @@ func TestHoopsAI_WatchlistByUserAndName(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s/%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSWatchlist, req.UserID, req.WatchlistName, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -432,7 +452,9 @@ func TestHoopsAI_WatchlistByUserAndName(t *testing.T) {
 			req:    model.HSWatchlistByUserAndNameRequest{WatchlistName: "FB", UserID: "123"},
 			hasErr: true,
 			fn: func(ctx context.Context, req model.HSWatchlistByUserAndNameRequest) *HoopsAI {
-				return &HoopsAI{}
+				return &HoopsAI{
+					logger: logrus.New(),
+				}
 			},
 		},
 		{
@@ -452,7 +474,8 @@ func TestHoopsAI_WatchlistByUserAndName(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s/%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSWatchlist, req.UserID, req.WatchlistName, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -467,7 +490,8 @@ func TestHoopsAI_WatchlistByUserAndName(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s/%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSWatchlist, req.UserID, req.WatchlistName, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -515,7 +539,8 @@ func TestHoopsAI_TopGainers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopGainers, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -536,7 +561,8 @@ func TestHoopsAI_TopGainers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopGainers, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -551,7 +577,8 @@ func TestHoopsAI_TopGainers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopGainers, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -599,7 +626,8 @@ func TestHoopsAI_TopLosers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopLosers, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -620,7 +648,8 @@ func TestHoopsAI_TopLosers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopLosers, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -635,7 +664,8 @@ func TestHoopsAI_TopLosers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopLosers, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -683,7 +713,8 @@ func TestHoopsAI_TopMovers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopMovers, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -704,7 +735,8 @@ func TestHoopsAI_TopMovers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopMovers, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -719,7 +751,8 @@ func TestHoopsAI_TopMovers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSTopMovers, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -767,7 +800,8 @@ func TestHoopsAI_DownTrend(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSDownTrend, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -788,7 +822,8 @@ func TestHoopsAI_DownTrend(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSDownTrend, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -803,7 +838,8 @@ func TestHoopsAI_DownTrend(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSDownTrend, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -851,7 +887,8 @@ func TestHoopsAI_UpTrend(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUpTrend, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -872,7 +909,8 @@ func TestHoopsAI_UpTrend(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUpTrend, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -887,7 +925,8 @@ func TestHoopsAI_UpTrend(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUpTrend, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -935,7 +974,8 @@ func TestHoopsAI_MarketOverview(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSMarketOverview, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -956,7 +996,8 @@ func TestHoopsAI_MarketOverview(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSMarketOverview, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -971,7 +1012,8 @@ func TestHoopsAI_MarketOverview(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSMarketOverview, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1019,7 +1061,8 @@ func TestHoopsAI_PriceTarget(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSPriceTarget, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1040,7 +1083,8 @@ func TestHoopsAI_PriceTarget(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSPriceTarget, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1055,7 +1099,8 @@ func TestHoopsAI_PriceTarget(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSPriceTarget, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1103,7 +1148,8 @@ func TestHoopsAI_UpcomingEarnings(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUpcomingEarnings, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1124,7 +1170,8 @@ func TestHoopsAI_UpcomingEarnings(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUpcomingEarnings, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1139,7 +1186,8 @@ func TestHoopsAI_UpcomingEarnings(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUpcomingEarnings, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1187,7 +1235,8 @@ func TestHoopsAI_RecentEarnings(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSRecentEarnings, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1208,7 +1257,8 @@ func TestHoopsAI_RecentEarnings(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSRecentEarnings, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1223,7 +1273,8 @@ func TestHoopsAI_RecentEarnings(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSRecentEarnings, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1271,7 +1322,8 @@ func TestHoopsAI_RecordHigh(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSRecordHigh, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1292,7 +1344,8 @@ func TestHoopsAI_RecordHigh(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSRecordHigh, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1307,7 +1360,8 @@ func TestHoopsAI_RecordHigh(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSRecordHigh, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1355,7 +1409,8 @@ func TestHoopsAI_UnusualHighVolume(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUnusualHighVolume, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1376,7 +1431,8 @@ func TestHoopsAI_UnusualHighVolume(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUnusualHighVolume, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1391,7 +1447,8 @@ func TestHoopsAI_UnusualHighVolume(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSUnusualHighVolume, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1439,7 +1496,8 @@ func TestHoopsAI_Data(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSAssets, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1460,7 +1518,8 @@ func TestHoopsAI_Data(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSAssets, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1475,7 +1534,8 @@ func TestHoopsAI_Data(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSAssets, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1523,7 +1583,8 @@ func TestHoopsAI_CustomerAssets(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSCustomerAssets, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1544,7 +1605,8 @@ func TestHoopsAI_CustomerAssets(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSCustomerAssets, req.DocGroup), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1559,7 +1621,8 @@ func TestHoopsAI_CustomerAssets(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?doc_group=%s&enable_html=true", model.URLInsightBase+model.URLInsightHSCustomerAssets, req.DocGroup), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1607,7 +1670,8 @@ func TestHoopsAI_GetUsers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightHSUsers, req), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1628,7 +1692,8 @@ func TestHoopsAI_GetUsers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightHSUsers, req), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1643,7 +1708,8 @@ func TestHoopsAI_GetUsers(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightHSUsers, req), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1691,7 +1757,8 @@ func TestHoopsAI_CreateUser(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1712,7 +1779,8 @@ func TestHoopsAI_CreateUser(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1727,7 +1795,8 @@ func TestHoopsAI_CreateUser(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer), nil, nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1775,7 +1844,8 @@ func TestHoopsAI_DeleteUser(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1796,7 +1866,8 @@ func TestHoopsAI_DeleteUser(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1811,7 +1882,8 @@ func TestHoopsAI_DeleteUser(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID), nil, nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1859,7 +1931,8 @@ func TestHoopsAI_CreateWatchlistByUser(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists", model.URLInsightBase+model.URLInsightHSUsers, customer, userID), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1880,7 +1953,8 @@ func TestHoopsAI_CreateWatchlistByUser(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists", model.URLInsightBase+model.URLInsightHSUsers, customer, userID), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1895,7 +1969,8 @@ func TestHoopsAI_CreateWatchlistByUser(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists", model.URLInsightBase+model.URLInsightHSUsers, customer, userID), nil, nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1945,7 +2020,8 @@ func TestHoopsAI_GetWatchlistByUser(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1968,7 +2044,8 @@ func TestHoopsAI_GetWatchlistByUser(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1985,7 +2062,8 @@ func TestHoopsAI_GetWatchlistByUser(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2035,7 +2113,8 @@ func TestHoopsAI_AddSymbolToWatchlist(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName, symbol), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2058,7 +2137,8 @@ func TestHoopsAI_AddSymbolToWatchlist(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName, symbol), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2075,7 +2155,8 @@ func TestHoopsAI_AddSymbolToWatchlist(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName, symbol), nil, nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2123,7 +2204,8 @@ func TestHoopsAI_DeleteSymbolFromWatchlist(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName, symbol), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2144,7 +2226,8 @@ func TestHoopsAI_DeleteSymbolFromWatchlist(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName, symbol), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2159,7 +2242,8 @@ func TestHoopsAI_DeleteSymbolFromWatchlist(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName, symbol), nil, nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2216,7 +2300,8 @@ func TestHoopsAI_AddSymbolsToWatchlist(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), bytes.NewBuffer(body), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2245,7 +2330,8 @@ func TestHoopsAI_AddSymbolsToWatchlist(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), bytes.NewBuffer(body), nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2268,7 +2354,8 @@ func TestHoopsAI_AddSymbolsToWatchlist(t *testing.T) {
 				cli.EXPECT().Post(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), bytes.NewBuffer(body), nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2316,7 +2403,8 @@ func TestHoopsAI_DeleteWatchlistByName(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2337,7 +2425,8 @@ func TestHoopsAI_DeleteWatchlistByName(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2352,7 +2441,8 @@ func TestHoopsAI_DeleteWatchlistByName(t *testing.T) {
 				cli.EXPECT().Delete(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, watchlistName), nil, nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2400,7 +2490,8 @@ func TestHoopsAI_RenameWatchlist(t *testing.T) {
 				cli.EXPECT().Put(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/rename/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, oldWatchlistName, newWatchlistName), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2421,7 +2512,8 @@ func TestHoopsAI_RenameWatchlist(t *testing.T) {
 				cli.EXPECT().Put(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/rename/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, oldWatchlistName, newWatchlistName), nil, nil).Return(httpResponse, nil)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -2436,7 +2528,8 @@ func TestHoopsAI_RenameWatchlist(t *testing.T) {
 				cli.EXPECT().Put(ctx, fmt.Sprintf("%s/%s/%s/watchlists/%s/rename/%s", model.URLInsightBase+model.URLInsightHSUsers, customer, userID, oldWatchlistName, newWatchlistName), nil, nil).Return(nil, hsTestErr)
 
 				return &HoopsAI{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/ipo/ipo.go
+++ b/client/ipo/ipo.go
@@ -15,17 +15,19 @@ import (
 )
 
 type IPO struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *IPO {
+func New(cli sdk.HTTPClient, logger *log.Logger) *IPO {
 	return &IPO{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (i *IPO) GetUpcomingIPOs(ctx context.Context, limit, offset int) (model.IPOResponse, error) {
-	log.Trace("GetUpcomingIPOs called")
+	i.logger.Trace("GetUpcomingIPOs called")
 
 	r, err := i.cli.Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightIPOsUpcoming, limit, offset), nil)
 	if err != nil {
@@ -42,7 +44,7 @@ func (i *IPO) GetUpcomingIPOs(ctx context.Context, limit, offset int) (model.IPO
 }
 
 func (i *IPO) GetRecentIPOs(ctx context.Context, req model.RecentIPORequest) (model.IPOResponse, error) {
-	log.Trace("GetRecentIPOs called")
+	i.logger.Trace("GetRecentIPOs called")
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/client/ipo/ipo_test.go
+++ b/client/ipo/ipo_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestIPO_GetUpcomingIPOs(t *testing.T) {
@@ -62,7 +63,8 @@ func TestIPO_GetUpcomingIPOs(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightIPOsUpcoming, limit, offset), nil).Return(httpResponse, nil)
 
 				return &IPO{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -84,7 +86,8 @@ func TestIPO_GetUpcomingIPOs(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightIPOsUpcoming, limit, offset), nil).Return(httpResponse, nil)
 
 				return &IPO{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -100,7 +103,8 @@ func TestIPO_GetUpcomingIPOs(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightIPOsUpcoming, limit, offset), nil).Return(nil, testErr)
 
 				return &IPO{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -170,7 +174,8 @@ func TestIPO_GetRecentIPOs(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIPOsRecent, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &IPO{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -195,7 +200,8 @@ func TestIPO_GetRecentIPOs(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIPOsRecent, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &IPO{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -214,7 +220,8 @@ func TestIPO_GetRecentIPOs(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIPOsRecent, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &IPO{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/logos/logos.go
+++ b/client/logos/logos.go
@@ -17,18 +17,20 @@ import (
 
 // Logos service provides API for getting different information about symbol's logo etc.
 type Logos struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *Logos {
+func New(cli sdk.HTTPClient, logger *log.Logger) *Logos {
 	return &Logos{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 // SymbolLogos returns logos info for symbol.
 func (l *Logos) SymbolLogos(ctx context.Context, symbol string) (model.SymbolLogosResponse, error) {
-	log.Trace("SymbolLogos called")
+	l.logger.Trace("SymbolLogos called")
 
 	r, err := l.cli.Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosSymbolLogos, symbol), nil)
 	if err != nil {
@@ -46,7 +48,7 @@ func (l *Logos) SymbolLogos(ctx context.Context, symbol string) (model.SymbolLog
 
 // SocialSymbolLogos returns urls of social network logos for symbol.
 func (l *Logos) SocialSymbolLogos(ctx context.Context, symbol string) (model.SymbolSocialsResponse, error) {
-	log.Trace("SocialSymbolLogos called")
+	l.logger.Trace("SocialSymbolLogos called")
 
 	r, err := l.cli.Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosSocialSymbolLogos, symbol), nil)
 	if err != nil {
@@ -64,7 +66,7 @@ func (l *Logos) SocialSymbolLogos(ctx context.Context, symbol string) (model.Sym
 
 // DirectSymbolLogo returns symbol logo as file.
 func (l *Logos) DirectSymbolLogo(ctx context.Context, symbol string) (io.ReadCloser, error) {
-	log.Trace("DirectSymbolLogo called")
+	l.logger.Trace("DirectSymbolLogo called")
 
 	r, err := l.cli.Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosDirectSymbolLogos, symbol), nil)
 	if err != nil {
@@ -76,7 +78,7 @@ func (l *Logos) DirectSymbolLogo(ctx context.Context, symbol string) (io.ReadClo
 
 // CryptoSymbolLogo returns crypto logos info for symbol
 func (l *Logos) CryptoSymbolLogo(ctx context.Context, symbol string) (model.SymbolLogosResponse, error) {
-	log.Trace("CryptoSymbolLogo called")
+	l.logger.Trace("CryptoSymbolLogo called")
 
 	r, err := l.cli.Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosCryptoSymbolLogo, symbol), nil)
 	if err != nil {
@@ -94,7 +96,7 @@ func (l *Logos) CryptoSymbolLogo(ctx context.Context, symbol string) (model.Symb
 
 // DirectCryptoSymbolLogo returns crypto symbol logo as file.
 func (l *Logos) DirectCryptoSymbolLogo(ctx context.Context, symbol string) (io.ReadCloser, error) {
-	log.Trace("DirectCryptoSymbolLogo called")
+	l.logger.Trace("DirectCryptoSymbolLogo called")
 
 	r, err := l.cli.Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosDirectCryptoSymbolLogos, symbol), nil)
 	if err != nil {
@@ -106,7 +108,7 @@ func (l *Logos) DirectCryptoSymbolLogo(ctx context.Context, symbol string) (io.R
 
 // MultiSymbolLogos returns logos details for many symbols.
 func (l *Logos) MultiSymbolLogos(ctx context.Context, req model.MultipleSymbolLogosRequest) ([]model.SymbolLogosResponse, error) {
-	log.Trace("MultiSymbolLogos called")
+	l.logger.Trace("MultiSymbolLogos called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -129,7 +131,7 @@ func (l *Logos) MultiSymbolLogos(ctx context.Context, req model.MultipleSymbolLo
 
 // ConvertedSymbolLogo returns converted logo as file.
 func (l *Logos) ConvertedSymbolLogo(ctx context.Context, req model.SymbolLogoConvertedRequest) (io.ReadCloser, error) {
-	log.Trace("ConvertedSymbolLogo called")
+	l.logger.Trace("ConvertedSymbolLogo called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -146,7 +148,7 @@ func (l *Logos) ConvertedSymbolLogo(ctx context.Context, req model.SymbolLogoCon
 
 // MultipleCryptoSymbolLogo returns logos details for many crypto symbols.
 func (l *Logos) MultipleCryptoSymbolLogo(ctx context.Context, req model.MultipleCryptoLogosRequest) ([]model.SymbolLogosResponse, error) {
-	log.Trace("MultipleCryptoSymbolLogo called")
+	l.logger.Trace("MultipleCryptoSymbolLogo called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -169,7 +171,7 @@ func (l *Logos) MultipleCryptoSymbolLogo(ctx context.Context, req model.Multiple
 
 // ConvertedCryptoSymbolLogo returns converted crypto logo as file.
 func (l *Logos) ConvertedCryptoSymbolLogo(ctx context.Context, req model.SymbolLogoConvertedRequest) (io.ReadCloser, error) {
-	log.Trace("ConvertedCryptoSymbolLogo called")
+	l.logger.Trace("ConvertedCryptoSymbolLogo called")
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/client/logos/logos_test.go
+++ b/client/logos/logos_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestLogos_SymbolLogos(t *testing.T) {
@@ -62,7 +63,8 @@ func TestLogos_SymbolLogos(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosSymbolLogos, symbol), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -83,7 +85,8 @@ func TestLogos_SymbolLogos(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosSymbolLogos, symbol), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -98,7 +101,8 @@ func TestLogos_SymbolLogos(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosSymbolLogos, symbol), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -169,7 +173,8 @@ func TestLogos_SocialSymbolLogos(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosSocialSymbolLogos, symbol), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -190,7 +195,8 @@ func TestLogos_SocialSymbolLogos(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosSocialSymbolLogos, symbol), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -205,7 +211,8 @@ func TestLogos_SocialSymbolLogos(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosSocialSymbolLogos, symbol), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -259,7 +266,8 @@ func TestLogos_DirectSymbolLogo(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosDirectSymbolLogos, symbol), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -274,7 +282,8 @@ func TestLogos_DirectSymbolLogo(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosDirectSymbolLogos, symbol), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -339,7 +348,8 @@ func TestLogos_CryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosCryptoSymbolLogo, symbol), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -360,7 +370,8 @@ func TestLogos_CryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosCryptoSymbolLogo, symbol), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -375,7 +386,8 @@ func TestLogos_CryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosCryptoSymbolLogo, symbol), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -429,7 +441,8 @@ func TestLogos_DirectCryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosDirectCryptoSymbolLogos, symbol), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -444,7 +457,8 @@ func TestLogos_DirectCryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightLogosDirectCryptoSymbolLogos, symbol), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -515,7 +529,8 @@ func TestLogos_MultiSymbolLogos(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosMultiSymbolLogos, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -538,7 +553,8 @@ func TestLogos_MultiSymbolLogos(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosMultiSymbolLogos, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -555,7 +571,8 @@ func TestLogos_MultiSymbolLogos(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosMultiSymbolLogos, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -613,7 +630,8 @@ func TestLogos_ConvertedSymbolLogo(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosConvertedSymbolLogos, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -630,7 +648,8 @@ func TestLogos_ConvertedSymbolLogo(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosConvertedSymbolLogos, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -701,7 +720,8 @@ func TestLogos_MultipleCryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosMultipleCryptoSymbolLogo, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -724,7 +744,8 @@ func TestLogos_MultipleCryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosMultipleCryptoSymbolLogo, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -741,7 +762,8 @@ func TestLogos_MultipleCryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosMultipleCryptoSymbolLogo, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -799,7 +821,8 @@ func TestLogos_ConvertedCryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosConvertedCryptoSymbolLogo, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -816,7 +839,8 @@ func TestLogos_ConvertedCryptoSymbolLogo(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightLogosConvertedCryptoSymbolLogo, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Logos{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/market/world_market.go
+++ b/client/market/world_market.go
@@ -13,17 +13,19 @@ import (
 )
 
 type WorldMarket struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *WorldMarket {
+func New(cli sdk.HTTPClient, logger *log.Logger) *WorldMarket {
 	return &WorldMarket{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (wm *WorldMarket) GetContinents(ctx context.Context, limit, offset int) ([]model.Continent, error) {
-	log.Trace("GetContinents called")
+	wm.logger.Trace("GetContinents called")
 
 	r, err := wm.cli.Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightContinents, limit, offset), nil)
 	if err != nil {
@@ -40,7 +42,7 @@ func (wm *WorldMarket) GetContinents(ctx context.Context, limit, offset int) ([]
 }
 
 func (wm *WorldMarket) GetRegions(ctx context.Context, limit, offset int) ([]model.Region, error) {
-	log.Trace("GetRegions called")
+	wm.logger.Trace("GetRegions called")
 
 	r, err := wm.cli.Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightRegions, limit, offset), nil)
 	if err != nil {
@@ -57,7 +59,7 @@ func (wm *WorldMarket) GetRegions(ctx context.Context, limit, offset int) ([]mod
 }
 
 func (wm *WorldMarket) GetCountryCodes(ctx context.Context, limit, offset int) ([]model.CountryCode, error) {
-	log.Trace("GetCountryCodes called")
+	wm.logger.Trace("GetCountryCodes called")
 
 	r, err := wm.cli.Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightCountryCodes, limit, offset), nil)
 	if err != nil {
@@ -74,7 +76,7 @@ func (wm *WorldMarket) GetCountryCodes(ctx context.Context, limit, offset int) (
 }
 
 func (wm *WorldMarket) GetGlobalIndexes(ctx context.Context, limit, offset int, continent, quoteType string) ([]model.GlobalIndexFull, error) {
-	log.Trace("GetGlobalIndexes called")
+	wm.logger.Trace("GetGlobalIndexes called")
 
 	r, err := wm.cli.Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d&continent=%s&quoteType=%s", model.URLInsightBase+model.URLInsightGlobalIndexes, limit, offset, continent, quoteType), nil)
 	if err != nil {

--- a/client/market/world_market_test.go
+++ b/client/market/world_market_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -17,7 +18,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestWorldMarket_GetContinents(t *testing.T) {
@@ -62,7 +63,8 @@ func TestWorldMarket_GetContinents(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightContinents, limit, offset), nil).Return(httpResponse, nil)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -84,7 +86,8 @@ func TestWorldMarket_GetContinents(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightContinents, limit, offset), nil).Return(httpResponse, nil)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -100,7 +103,8 @@ func TestWorldMarket_GetContinents(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightContinents, limit, offset), nil).Return(nil, testErr)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -166,7 +170,8 @@ func TestWorldMarket_GetRegions(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightRegions, limit, offset), nil).Return(httpResponse, nil)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -188,7 +193,8 @@ func TestWorldMarket_GetRegions(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightRegions, limit, offset), nil).Return(httpResponse, nil)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -204,7 +210,8 @@ func TestWorldMarket_GetRegions(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightRegions, limit, offset), nil).Return(nil, testErr)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -269,7 +276,8 @@ func TestWorldMarket_GetCountryCodes(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightCountryCodes, limit, offset), nil).Return(httpResponse, nil)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -291,7 +299,8 @@ func TestWorldMarket_GetCountryCodes(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightCountryCodes, limit, offset), nil).Return(httpResponse, nil)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -307,7 +316,8 @@ func TestWorldMarket_GetCountryCodes(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d", model.URLInsightBase+model.URLInsightCountryCodes, limit, offset), nil).Return(nil, testErr)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -373,7 +383,8 @@ func TestWorldMarket_GetGlobalIndexes(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d&continent=%s&quoteType=%s", model.URLInsightBase+model.URLInsightGlobalIndexes, limit, offset, continent, quoteType), nil).Return(httpResponse, nil)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -397,7 +408,8 @@ func TestWorldMarket_GetGlobalIndexes(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d&continent=%s&quoteType=%s", model.URLInsightBase+model.URLInsightGlobalIndexes, limit, offset, continent, quoteType), nil).Return(httpResponse, nil)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -415,7 +427,8 @@ func TestWorldMarket_GetGlobalIndexes(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?limit=%d&offset=%d&continent=%s&quoteType=%s", model.URLInsightBase+model.URLInsightGlobalIndexes, limit, offset, continent, quoteType), nil).Return(nil, testErr)
 
 				return &WorldMarket{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/news/news.go
+++ b/client/news/news.go
@@ -16,18 +16,20 @@ import (
 
 // News service provides API for getting news.
 type News struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *News {
+func New(cli sdk.HTTPClient, logger *log.Logger) *News {
 	return &News{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 // GetByFilter returns news by filters.
 func (c *News) GetByFilter(ctx context.Context, req model.NewsFilterRequest) (model.NewsResponse, error) {
-	log.Trace("GetByFilter called")
+	c.logger.Trace("GetByFilter called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -50,7 +52,7 @@ func (c *News) GetByFilter(ctx context.Context, req model.NewsFilterRequest) (mo
 
 // GetByID returns news by ID.
 func (c *News) GetByID(ctx context.Context, req model.NewsRequest) (model.News, error) {
-	log.Trace("GetByID called")
+	c.logger.Trace("GetByID called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -73,7 +75,7 @@ func (c *News) GetByID(ctx context.Context, req model.NewsRequest) (model.News, 
 
 // GetAvailableSymbols returns all available symbols of news.
 func (c *News) GetAvailableSymbols(ctx context.Context) ([]string, error) {
-	log.Trace("GetAvailableSymbols called")
+	c.logger.Trace("GetAvailableSymbols called")
 
 	r, err := c.cli.Get(ctx, model.URLInsightBase+model.URLInsightNewsSymbols, nil)
 	if err != nil {
@@ -91,7 +93,7 @@ func (c *News) GetAvailableSymbols(ctx context.Context) ([]string, error) {
 
 // GetAvailableAuthors returns all available authors for news. You can use it for GetByFilter filter.
 func (c *News) GetAvailableAuthors(ctx context.Context, symbol *string) ([]string, error) {
-	log.Trace("GetAvailableAuthors called")
+	c.logger.Trace("GetAvailableAuthors called")
 
 	body, err := prepareBodyWithSymbol(symbol)
 	if err != nil {
@@ -114,7 +116,7 @@ func (c *News) GetAvailableAuthors(ctx context.Context, symbol *string) ([]strin
 
 // GetAvailableChannels returns all available news channels.
 func (c *News) GetAvailableChannels(ctx context.Context, symbol *string) ([]string, error) {
-	log.Trace("GetAvailableChannels called")
+	c.logger.Trace("GetAvailableChannels called")
 
 	body, err := prepareBodyWithSymbol(symbol)
 	if err != nil {
@@ -137,7 +139,7 @@ func (c *News) GetAvailableChannels(ctx context.Context, symbol *string) ([]stri
 
 // GetAvailableTags returns all available news tags.
 func (c *News) GetAvailableTags(ctx context.Context, symbol *string) ([]string, error) {
-	log.Trace("GetAvailableTags called")
+	c.logger.Trace("GetAvailableTags called")
 
 	body, err := prepareBodyWithSymbol(symbol)
 	if err != nil {

--- a/client/news/news_test.go
+++ b/client/news/news_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -19,7 +20,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestNews_GetByFilter(t *testing.T) {
@@ -77,7 +78,8 @@ func TestNews_GetByFilter(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsFilter, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -100,7 +102,8 @@ func TestNews_GetByFilter(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsFilter, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -117,7 +120,8 @@ func TestNews_GetByFilter(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsFilter, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -191,7 +195,8 @@ func TestNews_GetByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsByID, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -214,7 +219,8 @@ func TestNews_GetByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsByID, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -231,7 +237,8 @@ func TestNews_GetByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsByID, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -285,7 +292,8 @@ func TestNews_GetAvailableSymbols(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightNewsSymbols, nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -305,7 +313,8 @@ func TestNews_GetAvailableSymbols(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightNewsSymbols, nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -319,7 +328,8 @@ func TestNews_GetAvailableSymbols(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightNewsSymbols, nil).Return(nil, testErr)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -381,7 +391,8 @@ func TestNews_GetAvailableAuthors(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsAuthors, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -402,7 +413,8 @@ func TestNews_GetAvailableAuthors(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsAuthors, nil, nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -425,7 +437,8 @@ func TestNews_GetAvailableAuthors(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsAuthors, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -442,7 +455,8 @@ func TestNews_GetAvailableAuthors(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsAuthors, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -504,7 +518,8 @@ func TestNews_GetAvailableChannels(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsChannels, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -525,7 +540,8 @@ func TestNews_GetAvailableChannels(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsChannels, nil, nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -548,7 +564,8 @@ func TestNews_GetAvailableChannels(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsChannels, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -565,7 +582,8 @@ func TestNews_GetAvailableChannels(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsChannels, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -627,7 +645,8 @@ func TestNews_GetAvailableTags(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsTags, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -648,7 +667,8 @@ func TestNews_GetAvailableTags(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsTags, nil, nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -671,7 +691,8 @@ func TestNews_GetAvailableTags(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsTags, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -688,7 +709,8 @@ func TestNews_GetAvailableTags(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightNewsTags, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &News{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/og/option_greeks.go
+++ b/client/og/option_greeks.go
@@ -14,17 +14,19 @@ import (
 )
 
 type OptionGreeks struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *OptionGreeks {
+func New(cli sdk.HTTPClient, logger *log.Logger) *OptionGreeks {
 	return &OptionGreeks{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (og *OptionGreeks) CalculateParams(ctx context.Context, req model.CalculateParamsRequest) (model.CalculateParamsResponse, error) {
-	log.Trace("CalculateParams called")
+	og.logger.Trace("CalculateParams called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -46,7 +48,7 @@ func (og *OptionGreeks) CalculateParams(ctx context.Context, req model.Calculate
 }
 
 func (og *OptionGreeks) CalculateMatrix(ctx context.Context, req model.CalculateMatrixParamsRequest) (model.CalculateMatrixResponse, error) {
-	log.Trace("CalculateMatrix called")
+	og.logger.Trace("CalculateMatrix called")
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/client/og/option_greeks_test.go
+++ b/client/og/option_greeks_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -17,7 +18,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestOptionGreeks_CalculateParams(t *testing.T) {
@@ -83,7 +84,8 @@ func TestOptionGreeks_CalculateParams(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOptionGreeksCalculateParams, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &OptionGreeks{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -106,7 +108,8 @@ func TestOptionGreeks_CalculateParams(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOptionGreeksCalculateParams, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &OptionGreeks{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -123,7 +126,8 @@ func TestOptionGreeks_CalculateParams(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOptionGreeksCalculateParams, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &OptionGreeks{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -221,7 +225,8 @@ func TestOptionGreeks_CalculateMatrix(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOptionGreeksCalculateMatrix, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &OptionGreeks{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -244,7 +249,8 @@ func TestOptionGreeks_CalculateMatrix(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOptionGreeksCalculateMatrix, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &OptionGreeks{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -261,7 +267,8 @@ func TestOptionGreeks_CalculateMatrix(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOptionGreeksCalculateMatrix, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &OptionGreeks{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/passport/passport.go
+++ b/client/passport/passport.go
@@ -14,17 +14,19 @@ import (
 )
 
 type Passport struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *Passport {
+func New(cli sdk.HTTPClient, logger *log.Logger) *Passport {
 	return &Passport{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (p *Passport) Articles(ctx context.Context, req model.ArticlesRequest) ([]model.Article, error) {
-	log.Trace("Articles called")
+	p.logger.Trace("Articles called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -46,7 +48,7 @@ func (p *Passport) Articles(ctx context.Context, req model.ArticlesRequest) ([]m
 }
 
 func (p *Passport) Newsfeed(ctx context.Context, req model.NewsfeedRequest) ([]model.Newsfeed, error) {
-	log.Trace("Newsfeed called")
+	p.logger.Trace("Newsfeed called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -68,7 +70,7 @@ func (p *Passport) Newsfeed(ctx context.Context, req model.NewsfeedRequest) ([]m
 }
 
 func (p *Passport) ArticleByID(ctx context.Context, req model.ArticleByIDRequest) (model.Article, error) {
-	log.Trace("ArticleByID called")
+	p.logger.Trace("ArticleByID called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -90,7 +92,7 @@ func (p *Passport) ArticleByID(ctx context.Context, req model.ArticleByIDRequest
 }
 
 func (p *Passport) SearchArticle(ctx context.Context, req model.SearchArticleRequest) ([]model.Article, error) {
-	log.Trace("SearchArticle called")
+	p.logger.Trace("SearchArticle called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -112,7 +114,7 @@ func (p *Passport) SearchArticle(ctx context.Context, req model.SearchArticleReq
 }
 
 func (p *Passport) AuthorProfile(ctx context.Context, req model.AuthorProfileRequest) ([]model.AuthorProfileResponse, error) {
-	log.Trace("AuthorProfile called")
+	p.logger.Trace("AuthorProfile called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -134,7 +136,7 @@ func (p *Passport) AuthorProfile(ctx context.Context, req model.AuthorProfileReq
 }
 
 func (p *Passport) MostPopularTags(ctx context.Context, req model.MostPopularTagsRequest) ([]model.TagShortInfo, error) {
-	log.Trace("MostPopularTags called")
+	p.logger.Trace("MostPopularTags called")
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/client/passport/passport_test.go
+++ b/client/passport/passport_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -17,7 +18,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestPassport_Articles(t *testing.T) {
@@ -62,7 +63,8 @@ func TestPassport_Articles(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportArticles, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -85,7 +87,8 @@ func TestPassport_Articles(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportArticles, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -102,7 +105,8 @@ func TestPassport_Articles(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportArticles, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -168,7 +172,8 @@ func TestPassport_Newsfeed(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportNewsFeed, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -191,7 +196,8 @@ func TestPassport_Newsfeed(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportNewsFeed, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -208,7 +214,8 @@ func TestPassport_Newsfeed(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportNewsFeed, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -272,7 +279,8 @@ func TestPassport_ArticleByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportArticleByID, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -295,7 +303,8 @@ func TestPassport_ArticleByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportArticleByID, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -312,7 +321,8 @@ func TestPassport_ArticleByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportArticleByID, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -378,7 +388,8 @@ func TestPassport_SearchArticle(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportSearchArticle, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -401,7 +412,8 @@ func TestPassport_SearchArticle(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportSearchArticle, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -418,7 +430,8 @@ func TestPassport_SearchArticle(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportSearchArticle, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -493,7 +506,8 @@ func TestPassport_AuthorProfile(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportAuthorProfile, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -516,7 +530,8 @@ func TestPassport_AuthorProfile(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportAuthorProfile, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -533,7 +548,8 @@ func TestPassport_AuthorProfile(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportAuthorProfile, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -602,7 +618,8 @@ func TestPassport_MostPopularTags(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportMostPopularTags, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -625,7 +642,8 @@ func TestPassport_MostPopularTags(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportMostPopularTags, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -642,7 +660,8 @@ func TestPassport_MostPopularTags(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightPassportMostPopularTags, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Passport{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/quotes/quotes.go
+++ b/client/quotes/quotes.go
@@ -16,17 +16,19 @@ import (
 
 // Quotes service returns quotes data.
 type Quotes struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *Quotes {
+func New(cli sdk.HTTPClient, logger *log.Logger) *Quotes {
 	return &Quotes{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (q *Quotes) GetQuotesEquityData(ctx context.Context, symbols, quoteType string) ([]model.QuoteEquityDataResponse, error) {
-	log.Trace("GetQuotesEquityData called")
+	q.logger.Trace("GetQuotesEquityData called")
 
 	r, err := q.cli.Get(ctx, fmt.Sprintf("%s?symbols=%s&quote_type=%s", model.URLInsightBase+model.URLInsightQuotesEquity, symbols, quoteType), nil)
 	if err != nil {
@@ -43,7 +45,7 @@ func (q *Quotes) GetQuotesEquityData(ctx context.Context, symbols, quoteType str
 }
 
 func (q *Quotes) GetQuoteHistory(ctx context.Context, req model.QuoteHistoryRequest) (model.QuoteHistoryResponse, error) {
-	log.Trace("GetQuoteHistory called")
+	q.logger.Trace("GetQuoteHistory called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -65,7 +67,7 @@ func (q *Quotes) GetQuoteHistory(ctx context.Context, req model.QuoteHistoryRequ
 }
 
 func (q *Quotes) GetIntradayQuotes(ctx context.Context, req model.IntradayRequest) ([]model.IntradayResponse, error) {
-	log.Trace("GetIntradayQuotes called")
+	q.logger.Trace("GetIntradayQuotes called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -87,7 +89,7 @@ func (q *Quotes) GetIntradayQuotes(ctx context.Context, req model.IntradayReques
 }
 
 func (q *Quotes) GetSingleHistoricalQuote(ctx context.Context, symbols, date string) (model.HistoricalQuote, error) {
-	log.Trace("GetSingleHistoricalQuote called")
+	q.logger.Trace("GetSingleHistoricalQuote called")
 
 	r, err := q.cli.Get(ctx, fmt.Sprintf("%s?symbols=%s&date=%s", model.URLInsightBase+model.URLInsightHistoricalQuote, symbols, date), nil)
 	if err != nil {

--- a/client/quotes/quotes_test.go
+++ b/client/quotes/quotes_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestQuotes_GetQuotesEquityData(t *testing.T) {
@@ -62,7 +63,8 @@ func TestQuotes_GetQuotesEquityData(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbols=%s&quote_type=%s", model.URLInsightBase+model.URLInsightQuotesEquity, symbols, quoteType), nil).Return(httpResponse, nil)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -84,7 +86,8 @@ func TestQuotes_GetQuotesEquityData(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbols=%s&quote_type=%s", model.URLInsightBase+model.URLInsightQuotesEquity, symbols, quoteType), nil).Return(httpResponse, nil)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -100,7 +103,8 @@ func TestQuotes_GetQuotesEquityData(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbols=%s&quote_type=%s", model.URLInsightBase+model.URLInsightQuotesEquity, symbols, quoteType), nil).Return(nil, testErr)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -186,7 +190,8 @@ func TestQuotes_GetQuoteHistory(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightQuoteHistory, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -211,7 +216,8 @@ func TestQuotes_GetQuoteHistory(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightQuoteHistory, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -230,7 +236,8 @@ func TestQuotes_GetQuoteHistory(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightQuoteHistory, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -307,7 +314,8 @@ func TestQuotes_GetIntradayQuotes(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIntradayQuotes, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -332,7 +340,8 @@ func TestQuotes_GetIntradayQuotes(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIntradayQuotes, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -351,7 +360,8 @@ func TestQuotes_GetIntradayQuotes(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIntradayQuotes, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Quotes{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/research/research.go
+++ b/client/research/research.go
@@ -15,17 +15,19 @@ import (
 )
 
 type Research struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *Research {
+func New(cli sdk.HTTPClient, logger *log.Logger) *Research {
 	return &Research{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (s *Research) GetCompanyProfile(ctx context.Context, symbol string) (model.CompanyProfile, error) {
-	log.Trace("GetCompanyProfile called")
+	s.logger.Trace("GetCompanyProfile called")
 
 	r, err := s.cli.Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightCompanyProfile, symbol), nil)
 	if err != nil {
@@ -42,7 +44,7 @@ func (s *Research) GetCompanyProfile(ctx context.Context, symbol string) (model.
 }
 
 func (s *Research) GetCombinedProfile(ctx context.Context, symbol string) (model.CompanyProfile, error) {
-	log.Trace("GetCombinedProfile called")
+	s.logger.Trace("GetCombinedProfile called")
 
 	r, err := s.cli.Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightQuoteProfile, symbol), nil)
 	if err != nil {
@@ -59,7 +61,7 @@ func (s *Research) GetCombinedProfile(ctx context.Context, symbol string) (model
 }
 
 func (s *Research) GetOwnershipsBySymbol(ctx context.Context, req model.GetOwnershipsBySymbolRequest) (model.GetOwnershipsBySymbolResponse, error) {
-	log.Trace("GetOwnershipsBySymbol called")
+	s.logger.Trace("GetOwnershipsBySymbol called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -81,7 +83,7 @@ func (s *Research) GetOwnershipsBySymbol(ctx context.Context, req model.GetOwner
 }
 
 func (s *Research) GetOwnershipsByID(ctx context.Context, req model.GetOwnershipsByIDRequest) (model.GetOwnershipsBySymbolResponse, error) {
-	log.Trace("GetOwnershipsByID called")
+	s.logger.Trace("GetOwnershipsByID called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -103,7 +105,7 @@ func (s *Research) GetOwnershipsByID(ctx context.Context, req model.GetOwnership
 }
 
 func (s *Research) GetEarningReleases(ctx context.Context, req model.EarningReleasesRequest) (model.EarningReleasesResponse, error) {
-	log.Trace("GetEarningReleases called")
+	s.logger.Trace("GetEarningReleases called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -125,7 +127,7 @@ func (s *Research) GetEarningReleases(ctx context.Context, req model.EarningRele
 }
 
 func (s *Research) GetSymbolFundamentals(ctx context.Context, req model.GetSymbolFundamentalsRequest) (model.GetSymbolFundamentalsResponse, error) {
-	log.Trace("GetSymbolFundamentals called")
+	s.logger.Trace("GetSymbolFundamentals called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -147,7 +149,7 @@ func (s *Research) GetSymbolFundamentals(ctx context.Context, req model.GetSymbo
 }
 
 func (s *Research) Screener(ctx context.Context, req model.StockScreenerRequest) (model.StockScreenerResponse, error) {
-	log.Trace("Screener called")
+	s.logger.Trace("Screener called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -169,7 +171,7 @@ func (s *Research) Screener(ctx context.Context, req model.StockScreenerRequest)
 }
 
 func (s *Research) StockMarketHeatmap(ctx context.Context, heatmapName, quoteType string) (model.StockMarketHeatmapResponse, error) {
-	log.Trace("StockMarketHeatmap called")
+	s.logger.Trace("StockMarketHeatmap called")
 
 	r, err := s.cli.Get(ctx, fmt.Sprintf("%s?heatmapName=%s&quoteType=%s", model.URLInsightBase+model.URLInsightHeatmaps, heatmapName, quoteType), nil)
 	if err != nil {
@@ -186,7 +188,7 @@ func (s *Research) StockMarketHeatmap(ctx context.Context, heatmapName, quoteTyp
 }
 
 func (s *Research) GetIndustriesPerformance(ctx context.Context, req model.GetIndustriesPerformanceRequest) (model.GetIndustriesPerformanceResponse, error) {
-	log.Trace("GetIndustriesPerformance called")
+	s.logger.Trace("GetIndustriesPerformance called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -208,7 +210,7 @@ func (s *Research) GetIndustriesPerformance(ctx context.Context, req model.GetIn
 }
 
 func (s *Research) GetMomentumRatioGraph(ctx context.Context, req model.MomentumRatioGraphRequest) (model.MomentumRatioGraphResponse, error) {
-	log.Trace("GetMomentumRatioGraph called")
+	s.logger.Trace("GetMomentumRatioGraph called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -230,7 +232,7 @@ func (s *Research) GetMomentumRatioGraph(ctx context.Context, req model.Momentum
 }
 
 func (s *Research) GetSeasonality(ctx context.Context, req model.SeasonalityRequest) (model.SeasonalityResponse, error) {
-	log.Trace("GetSeasonality called")
+	s.logger.Trace("GetSeasonality called")
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/client/research/research_test.go
+++ b/client/research/research_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestResearch_GetCompanyProfile(t *testing.T) {
@@ -59,7 +60,8 @@ func TestResearch_GetCompanyProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightCompanyProfile, symbol), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -80,7 +82,8 @@ func TestResearch_GetCompanyProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightCompanyProfile, symbol), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -95,7 +98,8 @@ func TestResearch_GetCompanyProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightCompanyProfile, symbol), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -157,7 +161,8 @@ func TestResearch_GetCombinedProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightQuoteProfile, symbol), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -178,7 +183,8 @@ func TestResearch_GetCombinedProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightQuoteProfile, symbol), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -193,7 +199,8 @@ func TestResearch_GetCombinedProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?symbol=%s", model.URLInsightBase+model.URLInsightQuoteProfile, symbol), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -271,7 +278,8 @@ func TestResearch_GetOwnershipsBySymbol(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightSymbolOwnerships, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -296,7 +304,8 @@ func TestResearch_GetOwnershipsBySymbol(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightSymbolOwnerships, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -315,7 +324,8 @@ func TestResearch_GetOwnershipsBySymbol(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightSymbolOwnerships, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -393,7 +403,8 @@ func TestResearch_GetOwnershipsByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOwnerships, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -418,7 +429,8 @@ func TestResearch_GetOwnershipsByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOwnerships, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -437,7 +449,8 @@ func TestResearch_GetOwnershipsByID(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightOwnerships, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -515,7 +528,8 @@ func TestResearch_GetEarningReleases(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightEarningsCalendar, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -540,7 +554,8 @@ func TestResearch_GetEarningReleases(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightEarningsCalendar, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -559,7 +574,8 @@ func TestResearch_GetEarningReleases(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightEarningsCalendar, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -623,7 +639,8 @@ func TestResearch_GetSymbolFundamentals(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundamentals, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -648,7 +665,8 @@ func TestResearch_GetSymbolFundamentals(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundamentals, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -667,7 +685,8 @@ func TestResearch_GetSymbolFundamentals(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightFundamentals, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -739,7 +758,8 @@ func TestResearch_Screener(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightStockScreener, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -764,7 +784,8 @@ func TestResearch_Screener(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightStockScreener, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -783,7 +804,8 @@ func TestResearch_Screener(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightStockScreener, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -855,7 +877,8 @@ func TestResearch_StockMarketHeatmap(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?heatmapName=%s&quoteType=%s", model.URLInsightBase+model.URLInsightHeatmaps, heatmapName, quoteType), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -877,7 +900,8 @@ func TestResearch_StockMarketHeatmap(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?heatmapName=%s&quoteType=%s", model.URLInsightBase+model.URLInsightHeatmaps, heatmapName, quoteType), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -893,7 +917,8 @@ func TestResearch_StockMarketHeatmap(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?heatmapName=%s&quoteType=%s", model.URLInsightBase+model.URLInsightHeatmaps, heatmapName, quoteType), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -969,7 +994,8 @@ func TestResearch_GetIndustriesPerformance(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIndustriesPerformance, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -996,7 +1022,8 @@ func TestResearch_GetIndustriesPerformance(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIndustriesPerformance, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1017,7 +1044,8 @@ func TestResearch_GetIndustriesPerformance(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightIndustriesPerformance, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1094,7 +1122,8 @@ func TestResearch_GetMomentumRatioGraph(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightGetMomentumRatioGraph, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1119,7 +1148,8 @@ func TestResearch_GetMomentumRatioGraph(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightGetMomentumRatioGraph, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1138,7 +1168,8 @@ func TestResearch_GetMomentumRatioGraph(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightGetMomentumRatioGraph, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1207,7 +1238,8 @@ func TestResearch_GetSeasonality(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightSeasonality, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1232,7 +1264,8 @@ func TestResearch_GetSeasonality(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightSeasonality, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1251,7 +1284,8 @@ func TestResearch_GetSeasonality(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightSeasonality, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &Research{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/client/tiprank/tiprank.go
+++ b/client/tiprank/tiprank.go
@@ -15,17 +15,19 @@ import (
 )
 
 type TipRank struct {
-	cli sdk.HTTPClient
+	cli    sdk.HTTPClient
+	logger *log.Logger
 }
 
-func New(cli sdk.HTTPClient) *TipRank {
+func New(cli sdk.HTTPClient, logger *log.Logger) *TipRank {
 	return &TipRank{
-		cli: cli,
+		cli:    cli,
+		logger: logger,
 	}
 }
 
 func (t *TipRank) AnalystConsensus(ctx context.Context, req model.AnalystConsensusRequest) ([]model.AnalystConsensusResponse, error) {
-	log.Trace("AnalystConsensus called")
+	t.logger.Trace("AnalystConsensus called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -47,7 +49,7 @@ func (t *TipRank) AnalystConsensus(ctx context.Context, req model.AnalystConsens
 }
 
 func (t *TipRank) LatestAnalystRatingsOnStock(ctx context.Context, req model.LatestAnalystRatingsOnStockRequest) ([]model.LatestAnalystRatingsOnStockResponse, error) {
-	log.Trace("LatestAnalystRatingsOnStock called")
+	t.logger.Trace("LatestAnalystRatingsOnStock called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -69,7 +71,7 @@ func (t *TipRank) LatestAnalystRatingsOnStock(ctx context.Context, req model.Lat
 }
 
 func (t *TipRank) LiveFeed(ctx context.Context, req model.LiveFeedRequest) ([]model.LiveFeedResponse, error) {
-	log.Trace("LiveFeed called")
+	t.logger.Trace("LiveFeed called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -91,7 +93,7 @@ func (t *TipRank) LiveFeed(ctx context.Context, req model.LiveFeedRequest) ([]mo
 }
 
 func (t *TipRank) TrendingStocks(ctx context.Context, req model.TrendingStocksRequest) ([]model.TrendingStocksResponse, error) {
-	log.Trace("TrendingStocks called")
+	t.logger.Trace("TrendingStocks called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -113,7 +115,7 @@ func (t *TipRank) TrendingStocks(ctx context.Context, req model.TrendingStocksRe
 }
 
 func (t *TipRank) AnalystPortfolios(ctx context.Context, req model.PortfoliosRequest) ([]model.PortfoliosResponse, error) {
-	log.Trace("AnalystPortfolios called")
+	t.logger.Trace("AnalystPortfolios called")
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -135,7 +137,7 @@ func (t *TipRank) AnalystPortfolios(ctx context.Context, req model.PortfoliosReq
 }
 
 func (t *TipRank) AnalystProfile(ctx context.Context, id string) (model.AnalystProfileResponse, error) {
-	log.Trace("AnalystProfile called")
+	t.logger.Trace("AnalystProfile called")
 
 	r, err := t.cli.Get(ctx, fmt.Sprintf("%s?id=%s", model.URLInsightBase+model.URLInsightTipRankAnalystProfile, id), nil)
 	if err != nil {
@@ -152,7 +154,7 @@ func (t *TipRank) AnalystProfile(ctx context.Context, id string) (model.AnalystP
 }
 
 func (t *TipRank) SectorConsensus(ctx context.Context) (model.SectorConsensusResponse, error) {
-	log.Trace("SectorConsensus called")
+	t.logger.Trace("SectorConsensus called")
 
 	r, err := t.cli.Get(ctx, model.URLInsightBase+model.URLInsightTipRankSectorConsensus, nil)
 	if err != nil {
@@ -169,7 +171,7 @@ func (t *TipRank) SectorConsensus(ctx context.Context) (model.SectorConsensusRes
 }
 
 func (t *TipRank) BestPerformingExperts(ctx context.Context, num int) ([]model.BestPerformingExpertsResponse, error) {
-	log.Trace("BestPerformingExperts called")
+	t.logger.Trace("BestPerformingExperts called")
 
 	r, err := t.cli.Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankBestPerformingExperts, num), nil)
 	if err != nil {
@@ -186,7 +188,7 @@ func (t *TipRank) BestPerformingExperts(ctx context.Context, num int) ([]model.B
 }
 
 func (t *TipRank) StocksSimilarStocks(ctx context.Context, ticker string) ([]string, error) {
-	log.Trace("StocksSimilarStocks called")
+	t.logger.Trace("StocksSimilarStocks called")
 
 	r, err := t.cli.Get(ctx, fmt.Sprintf("%s?ticker=%s", model.URLInsightBase+model.URLInsightTipRankStocksSimilarStocks, ticker), nil)
 	if err != nil {
@@ -203,7 +205,7 @@ func (t *TipRank) StocksSimilarStocks(ctx context.Context, ticker string) ([]str
 }
 
 func (t *TipRank) AnalystsExpertPictureStore(ctx context.Context) (model.AnalystsExpertPictureStoreResponse, error) {
-	log.Trace("AnalystsExpertPictureStore called")
+	t.logger.Trace("AnalystsExpertPictureStore called")
 
 	r, err := t.cli.Get(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystsExpertPictureStore, nil)
 	if err != nil {
@@ -220,7 +222,7 @@ func (t *TipRank) AnalystsExpertPictureStore(ctx context.Context) (model.Analyst
 }
 
 func (t *TipRank) SupportedTickers(ctx context.Context) (model.SupportedTickersResponse, error) {
-	log.Trace("SupportedTickers called")
+	t.logger.Trace("SupportedTickers called")
 
 	r, err := t.cli.Get(ctx, model.URLInsightBase+model.URLInsightTipRankSupportedTickers, nil)
 	if err != nil {
@@ -237,7 +239,7 @@ func (t *TipRank) SupportedTickers(ctx context.Context) (model.SupportedTickersR
 }
 
 func (t *TipRank) GeneralStockUpdates(ctx context.Context, utcTime, details string) (model.GeneralStockUpdatesResponse, error) {
-	log.Trace("GeneralStockUpdates called")
+	t.logger.Trace("GeneralStockUpdates called")
 
 	r, err := t.cli.Get(ctx, fmt.Sprintf("%s?utc_time=%s&details=%s", model.URLInsightBase+model.URLInsightTipRankGeneralStockUpdates, utcTime, details), nil)
 	if err != nil {
@@ -254,7 +256,7 @@ func (t *TipRank) GeneralStockUpdates(ctx context.Context, utcTime, details stri
 }
 
 func (t *TipRank) InsidersOverview(ctx context.Context, expertUID string) (model.InsidersOverviewResponse, error) {
-	log.Trace("InsidersOverview called")
+	t.logger.Trace("InsidersOverview called")
 
 	r, err := t.cli.Get(ctx, fmt.Sprintf("%s?expert_uid=%s", model.URLInsightBase+model.URLInsightTipRankInsidersOverview, expertUID), nil)
 	if err != nil {
@@ -271,7 +273,7 @@ func (t *TipRank) InsidersOverview(ctx context.Context, expertUID string) (model
 }
 
 func (t *TipRank) InsidersBestPerformingExperts(ctx context.Context, num int) ([]model.InsidersBestPerformingExpertsResponse, error) {
-	log.Trace("InsidersBestPerformingExperts called")
+	t.logger.Trace("InsidersBestPerformingExperts called")
 
 	r, err := t.cli.Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankInsidersBestPerformingExperts, num), nil)
 	if err != nil {
@@ -288,7 +290,7 @@ func (t *TipRank) InsidersBestPerformingExperts(ctx context.Context, num int) ([
 }
 
 func (t *TipRank) InsidersLiveFeed(ctx context.Context, num int, sort string) ([]model.InsidersLiveFeedResponse, error) {
-	log.Trace("InsidersLiveFeed called")
+	t.logger.Trace("InsidersLiveFeed called")
 
 	r, err := t.cli.Get(ctx, fmt.Sprintf("%s?num=%d&sort=%s", model.URLInsightBase+model.URLInsightTipRankInsidersLiveFeed, num, sort), nil)
 	if err != nil {
@@ -305,7 +307,7 @@ func (t *TipRank) InsidersLiveFeed(ctx context.Context, num int, sort string) ([
 }
 
 func (t *TipRank) HedgeFundsBestPerformingExperts(ctx context.Context, num int) ([]model.HedgeFundsBestPerformingExpertsResponse, error) {
-	log.Trace("HedgeFundsBestPerformingExperts called")
+	t.logger.Trace("HedgeFundsBestPerformingExperts called")
 
 	r, err := t.cli.Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankHedgefundsBestPerformingExperts, num), nil)
 	if err != nil {

--- a/client/tiprank/tiprank_test.go
+++ b/client/tiprank/tiprank_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	assert.NotNil(t, New(nil))
+	assert.NotNil(t, New(nil, nil))
 }
 
 func TestTipRank_AnalystConsensus(t *testing.T) {
@@ -74,7 +75,8 @@ func TestTipRank_AnalystConsensus(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystConsensus, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -99,7 +101,8 @@ func TestTipRank_AnalystConsensus(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystConsensus, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -118,7 +121,8 @@ func TestTipRank_AnalystConsensus(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystConsensus, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -190,7 +194,8 @@ func TestTipRank_LatestAnalystRatingsOnStock(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystMulti, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -215,7 +220,8 @@ func TestTipRank_LatestAnalystRatingsOnStock(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystMulti, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -234,7 +240,8 @@ func TestTipRank_LatestAnalystRatingsOnStock(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystMulti, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -305,7 +312,8 @@ func TestTipRank_LiveFeed(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankLiveFeed, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -330,7 +338,8 @@ func TestTipRank_LiveFeed(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankLiveFeed, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -349,7 +358,8 @@ func TestTipRank_LiveFeed(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankLiveFeed, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -418,7 +428,8 @@ func TestTipRank_TrendingStocks(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankTrendingStocks, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -443,7 +454,8 @@ func TestTipRank_TrendingStocks(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankTrendingStocks, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -462,7 +474,8 @@ func TestTipRank_TrendingStocks(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankTrendingStocks, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -530,7 +543,8 @@ func TestTipRank_AnalystPortfolios(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystPortfolio, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -555,7 +569,8 @@ func TestTipRank_AnalystPortfolios(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystPortfolio, bytes.NewBuffer(bb), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -574,7 +589,8 @@ func TestTipRank_AnalystPortfolios(t *testing.T) {
 				cli.EXPECT().Post(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystPortfolio, bytes.NewBuffer(bb), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -637,7 +653,8 @@ func TestTipRank_AnalystProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?id=%s", model.URLInsightBase+model.URLInsightTipRankAnalystProfile, id), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -658,7 +675,8 @@ func TestTipRank_AnalystProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?id=%s", model.URLInsightBase+model.URLInsightTipRankAnalystProfile, id), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -673,7 +691,8 @@ func TestTipRank_AnalystProfile(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?id=%s", model.URLInsightBase+model.URLInsightTipRankAnalystProfile, id), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -748,7 +767,8 @@ func TestTipRank_SectorConsensus(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankSectorConsensus, nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -768,7 +788,8 @@ func TestTipRank_SectorConsensus(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankSectorConsensus, nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -782,7 +803,8 @@ func TestTipRank_SectorConsensus(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankSectorConsensus, nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -847,7 +869,8 @@ func TestTipRank_BestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankBestPerformingExperts, num), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -868,7 +891,8 @@ func TestTipRank_BestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankBestPerformingExperts, num), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -883,7 +907,8 @@ func TestTipRank_BestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankBestPerformingExperts, num), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -939,7 +964,8 @@ func TestTipRank_StocksSimilarStocks(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?ticker=%s", model.URLInsightBase+model.URLInsightTipRankStocksSimilarStocks, ticker), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -960,7 +986,8 @@ func TestTipRank_StocksSimilarStocks(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?ticker=%s", model.URLInsightBase+model.URLInsightTipRankStocksSimilarStocks, ticker), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -975,7 +1002,8 @@ func TestTipRank_StocksSimilarStocks(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?ticker=%s", model.URLInsightBase+model.URLInsightTipRankStocksSimilarStocks, ticker), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1031,7 +1059,8 @@ func TestTipRank_AnalystsExpertPictureStore(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystsExpertPictureStore, nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1051,7 +1080,8 @@ func TestTipRank_AnalystsExpertPictureStore(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystsExpertPictureStore, nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1065,7 +1095,8 @@ func TestTipRank_AnalystsExpertPictureStore(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankAnalystsExpertPictureStore, nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1121,7 +1152,8 @@ func TestTipRank_SupportedTickers(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankSupportedTickers, nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1141,7 +1173,8 @@ func TestTipRank_SupportedTickers(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankSupportedTickers, nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1155,7 +1188,8 @@ func TestTipRank_SupportedTickers(t *testing.T) {
 				cli.EXPECT().Get(ctx, model.URLInsightBase+model.URLInsightTipRankSupportedTickers, nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1214,7 +1248,8 @@ func TestTipRank_GeneralStockUpdates(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?utc_time=%s&details=%s", model.URLInsightBase+model.URLInsightTipRankGeneralStockUpdates, utcTime, details), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1236,7 +1271,8 @@ func TestTipRank_GeneralStockUpdates(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?utc_time=%s&details=%s", model.URLInsightBase+model.URLInsightTipRankGeneralStockUpdates, utcTime, details), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1252,7 +1288,8 @@ func TestTipRank_GeneralStockUpdates(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?utc_time=%s&details=%s", model.URLInsightBase+model.URLInsightTipRankGeneralStockUpdates, utcTime, details), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1311,7 +1348,8 @@ func TestTipRank_InsidersOverview(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?expert_uid=%s", model.URLInsightBase+model.URLInsightTipRankInsidersOverview, expertUID), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1332,7 +1370,8 @@ func TestTipRank_InsidersOverview(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?expert_uid=%s", model.URLInsightBase+model.URLInsightTipRankInsidersOverview, expertUID), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1347,7 +1386,8 @@ func TestTipRank_InsidersOverview(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?expert_uid=%s", model.URLInsightBase+model.URLInsightTipRankInsidersOverview, expertUID), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1411,7 +1451,8 @@ func TestTipRank_InsidersBestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankInsidersBestPerformingExperts, num), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1432,7 +1473,8 @@ func TestTipRank_InsidersBestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankInsidersBestPerformingExperts, num), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1447,7 +1489,8 @@ func TestTipRank_InsidersBestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankInsidersBestPerformingExperts, num), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1512,7 +1555,8 @@ func TestTipRank_InsidersLiveFeed(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d&sort=%s", model.URLInsightBase+model.URLInsightTipRankInsidersLiveFeed, num, sort), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1534,7 +1578,8 @@ func TestTipRank_InsidersLiveFeed(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d&sort=%s", model.URLInsightBase+model.URLInsightTipRankInsidersLiveFeed, num, sort), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1550,7 +1595,8 @@ func TestTipRank_InsidersLiveFeed(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d&sort=%s", model.URLInsightBase+model.URLInsightTipRankInsidersLiveFeed, num, sort), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1613,7 +1659,8 @@ func TestTipRank_HedgeFundsBestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankHedgefundsBestPerformingExperts, num), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1634,7 +1681,8 @@ func TestTipRank_HedgeFundsBestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankHedgefundsBestPerformingExperts, num), nil).Return(httpResponse, nil)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},
@@ -1649,7 +1697,8 @@ func TestTipRank_HedgeFundsBestPerformingExperts(t *testing.T) {
 				cli.EXPECT().Get(ctx, fmt.Sprintf("%s?num=%d", model.URLInsightBase+model.URLInsightTipRankHedgefundsBestPerformingExperts, num), nil).Return(nil, testErr)
 
 				return &TipRank{
-					cli: cli,
+					cli:    cli,
+					logger: logrus.New(),
 				}
 			},
 		},

--- a/storage/default.go
+++ b/storage/default.go
@@ -3,8 +3,6 @@ package storage
 import (
 	"context"
 	"sync"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // InMemoryStorage is just a simple in-memory storage.
@@ -19,8 +17,6 @@ func NewInMemoryStorage() *InMemoryStorage {
 }
 
 func (s *InMemoryStorage) Store(_ context.Context, data []byte) error {
-	log.Trace("InMemoryStorage: method Store called")
-
 	s.mx.Lock()
 	defer s.mx.Unlock()
 	s.data = data
@@ -29,8 +25,6 @@ func (s *InMemoryStorage) Store(_ context.Context, data []byte) error {
 }
 
 func (s *InMemoryStorage) Get(_ context.Context) ([]byte, error) {
-	log.Trace("InMemoryStorage: method Get called")
-
 	s.mx.RLock()
 	defer s.mx.RUnlock()
 

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/redis/go-redis/v9"
-	log "github.com/sirupsen/logrus"
 
 	sdk "github.com/OrbisSystems/orbis-sdk-go/interfaces"
 )
@@ -65,13 +64,9 @@ func NewRedisStorageWithOwnCli(cfg Config, cli sdk.RedisRepo) (*Client, error) {
 }
 
 func (c *Client) Store(ctx context.Context, data []byte) error {
-	log.Trace("Redis: method Store called")
-
 	return c.cli.Set(ctx, c.keyForStore, data, 0).Err()
 }
 
 func (c *Client) Get(ctx context.Context) ([]byte, error) {
-	log.Trace("Redis: method Get called")
-
 	return c.cli.Get(ctx, c.keyForStore).Bytes()
 }


### PR DESCRIPTION
Orbis SDK uses logrus package for logging purposes. More precisely, it uses a global instance of logrus. If an SDK caller also uses a global logrus instance, this leads to a situation where logger parameters get overwritten based on the call order. Example:
```
	log.SetLevel(log.ErrorLevel)
        log.Error("error") // yields output as log level is error

	// log level fatal
	cfg := config.Config{
		Host:     "host-to-orbis-server",
		LogLevel: config.FatalLogLevel,
	}

	tokenStorage, err := storage.NewRedisStorage(storage.Config{
		Host: "localhost",
		Port: 6379,
	})
	if err != nil {
		panic(err)
	}

	authSys := auth.New(tokenStorage)
	cli := client.NewSDK(cfg, authSys)

	log.Error("error") // yields no output as log level is set to fatal globally
```
This pull request addresses the bug described above by replacing calls to global instance with calls to local instance of logrus.
