### PR TITLE
Fix/Duplicate request error loop on token refresh

### DIFF
--- a/client/account/account.go
+++ b/client/account/account.go
@@ -64,7 +64,7 @@ func (a *Account) watchTokenRefresh() {
 
 				// NOTE: As of now, there is no way to recover from a situation where token can't be updated
 				// this will be addressed in the future
-				return
+				refreshTicker.Reset(5 * time.Minute)
 			}
 
 			retryNumber = 0

--- a/client/account/account_test.go
+++ b/client/account/account_test.go
@@ -185,8 +185,6 @@ func TestAccount_LoginByEmail(t *testing.T) {
 					Auth:   auth,
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -215,8 +213,6 @@ func TestAccount_LoginByEmail(t *testing.T) {
 					Auth:   auth,
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -242,8 +238,6 @@ func TestAccount_LoginByEmail(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -262,8 +256,6 @@ func TestAccount_LoginByEmail(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -343,8 +335,6 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 					Auth:   auth,
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -373,8 +363,6 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 					Auth:   auth,
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -400,8 +388,6 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -420,8 +406,6 @@ func TestAccount_LoginByAPIKey(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -489,8 +473,6 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -516,8 +498,6 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -536,8 +516,6 @@ func TestAccount_CreateAPIKey(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -615,8 +593,6 @@ func TestAccount_RefreshToken(t *testing.T) {
 					Auth:   auth,
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -646,8 +622,6 @@ func TestAccount_RefreshToken(t *testing.T) {
 					Auth:   auth,
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -676,8 +650,6 @@ func TestAccount_RefreshToken(t *testing.T) {
 					Auth:   auth,
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -699,8 +671,6 @@ func TestAccount_RefreshToken(t *testing.T) {
 					Auth:   auth,
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -716,8 +686,6 @@ func TestAccount_RefreshToken(t *testing.T) {
 				return &Account{
 					Auth:   auth,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -733,8 +701,6 @@ func TestAccount_RefreshToken(t *testing.T) {
 				return &Account{
 					Auth:   auth,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -795,8 +761,6 @@ func TestAccount_GetUserByID(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -820,8 +784,6 @@ func TestAccount_GetUserByID(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -838,8 +800,6 @@ func TestAccount_GetUserByID(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},

--- a/client/account/account_v2_test.go
+++ b/client/account/account_v2_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -71,8 +70,6 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -97,8 +94,6 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},
@@ -123,8 +118,6 @@ func TestAccount_GetB2BUsersV2(t *testing.T) {
 				return &Account{
 					cli:    cli,
 					logger: logrus.New(),
-
-					refreshTicker: time.NewTicker(time.Hour * 100),
 				}
 			},
 		},


### PR DESCRIPTION
User authentication rate-limiting could cause SDK to go into the token refresh loop when SDK calls token refresh too often, resulting in a 425 response code. The precondition for this is running multiple instances of the SDK with the same credentials.

This pull request adds exponential backoff in the case of refresh failure along with random timing offsets, which should make 425 less likely. 

It doesn't eliminate the possibility completely, as this will require sync between multiple instances of the program, for which there is no such mechanism in the SDK at the moment.