### PR TITLE
Refactor/SetLoginCallback function. Refresh token flow rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ cli.Account.LoginByEmail(ctx, model.LoginByEmailRequest{
     DeviceID:   "devideID",
     RememberMe: true,
 })
+
+// set login function that will be called in case token refresh is failed multiple times
+cli.Account.SetLoginCallback(func(ctx context.Context) error {
+	return cli.Account.LoginByEmail(ctx, model.LoginByEmailRequest{
+    	Email:      "test@test.com",
+    	Password:   "passpass",
+    	DeviceID:   "devideID",
+    	RememberMe: true,
+    })
+})
+
 ```
 Also, you can use API Keys for loging using `LoginByAPIKey` method.
 

--- a/interfaces/interface.go
+++ b/interfaces/interface.go
@@ -45,6 +45,7 @@ type AccountService interface {
 	RefreshToken(ctx context.Context) error
 	GetUserByID(ctx context.Context, id int) (model.GetB2BUserByIDResponse, error)
 	GetB2BUsersV2(ctx context.Context, req model.GetB2BUsersV2Request) (model.GetB2BUsersV2Response, error)
+	SetLoginCallback(callback func(ctx context.Context) error)
 }
 
 type NewsService interface {


### PR DESCRIPTION
Added `SetLoginCallback` function that should allow SDK to recover in cases when token refresh is impossible, for example, in case when session is dropped on the server side. 

One should be aware that there is still possibility of authentication failure while doing request as recovery is asynchronous. This will be addressed in future updates.